### PR TITLE
Dependency on sidekiq 2.2.0 and up

### DIFF
--- a/sidekiq-unique-jobs.gemspec
+++ b/sidekiq-unique-jobs.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "sidekiq-unique-jobs"
   gem.require_paths = ["lib"]
   gem.version       = SidekiqUniqueJobs::VERSION
-  gem.add_dependency                  'sidekiq', '~> 2.2.0'
+  gem.add_dependency                  'sidekiq', '>= 2.2.0'
   gem.add_development_dependency      'minitest', '~> 3'
   gem.add_development_dependency      'sinatra'
   gem.add_development_dependency      'slim'


### PR DESCRIPTION
Tested with sidekiq 2.3.2 and working. Changing dependency to match (>= 2.2.0)
