### PR TITLE
Remove unnecessary log messages

### DIFF
--- a/lib/sidekiq-unique-jobs/middleware/server/unique_jobs.rb
+++ b/lib/sidekiq-unique-jobs/middleware/server/unique_jobs.rb
@@ -5,9 +5,7 @@ module SidekiqUniqueJobs
     module Server
       class UniqueJobs
         def call(*args)
-          logger.info("About to process a job with args #{args.inspect}")
           yield
-          logger.info("Done processing a job with args #{args.inspect}")
         ensure
           item = args[1]
           md5_arguments = {:class => item['class'], :queue => item['queue'], :args => item['args']}


### PR DESCRIPTION
The information logging of the message contents in this plugin are redundant and cause excess log messages in production.  I have removed them in this PR.  Alternative would be to have them as debug messages, in which case I would suggest identifying them as coming from UniqueJobs Plugin.  Since the plugin chain is called regardless of whether a workers uses this plugin, the log message appears for every job, regardless.
