### PR TITLE
Adding the unique prefix option

### DIFF
--- a/lib/sidekiq-unique-jobs.rb
+++ b/lib/sidekiq-unique-jobs.rb
@@ -1,2 +1,10 @@
 require 'sidekiq-unique-jobs/middleware'
 require "sidekiq-unique-jobs/version"
+require "sidekiq-unique-jobs/config"
+require "sidekiq-unique-jobs/payload_helper"
+
+module SidekiqUniqueJobs
+  def self.config
+    SidekiqUniqueJobs::Config
+  end
+end

--- a/lib/sidekiq-unique-jobs/config.rb
+++ b/lib/sidekiq-unique-jobs/config.rb
@@ -1,0 +1,11 @@
+module SidekiqUniqueJobs
+  class Config
+    def self.unique_prefix=(prefix)
+      @unique_prefix = prefix
+    end
+
+    def self.unique_prefix
+      @unique_prefix || "sidekiq_unique"
+    end
+  end
+end

--- a/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
+++ b/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
@@ -13,8 +13,7 @@ module SidekiqUniqueJobs
 
           if enabled
 
-            md5_arguments = {:class => item['class'], :queue => item['queue'], :args => item['args']}
-            payload_hash = Digest::MD5.hexdigest(Sidekiq.dump_json(md5_arguments))
+            payload_hash = SidekiqUniqueJobs::PayloadHelper.get_payload(item['class'], item['queue'], item['args'])
 
             unique = false
 

--- a/lib/sidekiq-unique-jobs/middleware/server/unique_jobs.rb
+++ b/lib/sidekiq-unique-jobs/middleware/server/unique_jobs.rb
@@ -8,9 +8,9 @@ module SidekiqUniqueJobs
           yield
         ensure
           item = args[1]
-          md5_arguments = {:class => item['class'], :queue => item['queue'], :args => item['args']}
-          hash = Digest::MD5.hexdigest(Sidekiq.dump_json(md5_arguments))
-          Sidekiq.redis {|conn| conn.del(hash) }
+          payload_hash = SidekiqUniqueJobs::PayloadHelper.get_payload(item['class'], item['queue'], item['args'])
+
+          Sidekiq.redis {|conn| conn.del(payload_hash) }
         end
 
         protected

--- a/lib/sidekiq-unique-jobs/payload_helper.rb
+++ b/lib/sidekiq-unique-jobs/payload_helper.rb
@@ -1,0 +1,8 @@
+module SidekiqUniqueJobs
+  class PayloadHelper
+    def self.get_payload(klass, queue, *args)
+      md5_arguments = {:class => klass, :queue => queue, :args => args}
+      "#{SidekiqUniqueJobs::Config.unique_prefix}:#{Digest::MD5.hexdigest(Sidekiq.dump_json(md5_arguments))}"
+    end
+  end
+end


### PR DESCRIPTION
This solves a few problems with the unique jobs
1. Ability to delete all the unique payloads in a snap, without the jobs
   actually being performed. For example when you delete an entire queue
   for some reasons, you would like it to get queued up again.
2. Obscure keys for the unique payloads, this way you can better
   uidentify it.

Also refactored the payloads a bit, cleaned up etc..
