### PR TITLE
Default expiration now configurable

### DIFF
--- a/lib/sidekiq-unique-jobs/config.rb
+++ b/lib/sidekiq-unique-jobs/config.rb
@@ -7,5 +7,13 @@ module SidekiqUniqueJobs
     def self.unique_prefix
       @unique_prefix || "sidekiq_unique"
     end
+
+    def self.default_expiration=(expiration)
+      @expiration = expiration
+    end
+
+    def self.default_expiration
+      @expiration || 30 * 60
+    end
   end
 end

--- a/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
+++ b/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
@@ -4,8 +4,6 @@ module SidekiqUniqueJobs
   module Middleware
     module Client
       class UniqueJobs
-        HASH_KEY_EXPIRATION = 30 * 60
-
         def call(worker_class, item, queue)
 
           enabled = worker_class.get_sidekiq_options['unique']
@@ -24,7 +22,7 @@ module SidekiqUniqueJobs
               if conn.get(payload_hash)
                 conn.unwatch
               else
-                expires_at = unique_job_expiration || HASH_KEY_EXPIRATION
+                expires_at = unique_job_expiration || SidekiqUniqueJobs::Config.default_expiration
                 expires_at = ((Time.at(item['at']) - Time.now.utc) + expires_at).to_i if item['at']
 
                 unique = conn.multi do

--- a/test/lib/sidekiq/test_client.rb
+++ b/test/lib/sidekiq/test_client.rb
@@ -3,6 +3,7 @@ require 'sidekiq/worker'
 require "sidekiq-unique-jobs"
 require 'sidekiq/scheduled'
 require 'sidekiq-unique-jobs/middleware/server/unique_jobs'
+require 'sidekiq-unique-jobs/config'
 
 class TestClient < MiniTest::Unit::TestCase
   describe 'with real redis' do
@@ -49,7 +50,7 @@ class TestClient < MiniTest::Unit::TestCase
       QueueWorker.sidekiq_options :unique => true
 
       at = 15.minutes.from_now
-      expected_expires_at = (Time.at(at) - Time.now.utc) + SidekiqUniqueJobs::Middleware::Client::UniqueJobs::HASH_KEY_EXPIRATION
+      expected_expires_at = (Time.at(at) - Time.now.utc) + SidekiqUniqueJobs::Config.default_expiration
 
       QueueWorker.perform_in(at, 'mike')
       payload_hash = SidekiqUniqueJobs::PayloadHelper.get_payload("TestClient::QueueWorker", "customqueue", ['mike'])


### PR DESCRIPTION
Setting the default expiration as a configuration option with the same default.
