### PR TITLE
Add support for unique when using Sidekiq's delay function

### DIFF
--- a/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
+++ b/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
@@ -8,7 +8,7 @@ module SidekiqUniqueJobs
 
         def call(worker_class, item, queue)
 
-          enabled = worker_class.get_sidekiq_options['unique']
+          enabled = worker_class.get_sidekiq_options['unique'] || item['unique']
           unique_job_expiration = worker_class.get_sidekiq_options['unique_job_expiration']
 
           if enabled


### PR DESCRIPTION
When queueing something calling class.delay(unique: true) Sidekiq doesn't pass the unique param as part of the sidekiq_options hash. Testing the raw params fixes the problem.
