### PR TITLE
Rely on Sidekiq's String#constantize extension instead of rolling our own

### DIFF
--- a/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
+++ b/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
@@ -48,27 +48,12 @@ module SidekiqUniqueJobs
 
         # Attempt to constantize a string worker_class argument, always 
         # failing back to the original argument.
-        # Duplicates Rails' String.constantize logic for non-Rails cases.
         def worker_class_constantize(worker_class)
           if worker_class.is_a?(String)
-            if worker_class.respond_to?(:constantize)
-              worker_class.constantize
-            else
-              # duplicated logic from Rails 3.2.13 ActiveSupport::Inflector
-              # https://github.com/rails/rails/blob/9e0b3fc7cfba43af55377488f991348e2de24515/activesupport/lib/active_support/inflector/methods.rb#L213
-              names = worker_class.split('::')
-              names.shift if names.empty? || names.first.empty?
-              constant = Object
-              names.each do |name|
-                constant = constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
-              end
-              constant
-            end
+            worker_class.constantize rescue worker_class
           else
             worker_class
           end
-        rescue
-          worker_class
         end
 
       end


### PR DESCRIPTION
As per discussion on issue #17, I've dropped the custom implementation of 
String.constantize in favour of using the built-in Sidekiq implementation.

Currently this helper method behaves the same as it did previously, if the
string could not be constantized, no exception is raised, and the original
string argument is returned.

Note that calling `klass.get_sidekiq_options` on the next line of `call` is 
going to raise an exception anyway if `klass` is a string.
