### PR TITLE
Make unlock/yield order configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ middleware, the JSON is passed directly to the worker `#perform` method. So, you
 arguments are different when enqueuing than they are when performing. Your `unique_args` method may need to
 account for this.
 
+### Unlock Ordering
+
+By default the server middleware will release the worker lock after yielding to the next middleware or worker. Alternatively, this can be changed by passing the `unique_unlock_order` option:
+
+```ruby
+class UniqueJobWithFilterMethod
+  include Sidekiq::Worker
+  sidekiq_options unique: true,
+                  unique_unlock_order: :before_yield
+
+  ...
+
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/sidekiq-unique-jobs/config.rb
+++ b/lib/sidekiq-unique-jobs/config.rb
@@ -23,5 +23,13 @@ module SidekiqUniqueJobs
     def self.default_expiration
       @expiration || 30 * 60
     end
+
+    def self.default_unlock_order=(order)
+      @default_unlock_order = order
+    end
+
+    def self.default_unlock_order
+      @default_unlock_order || :after_yield
+    end
   end
 end

--- a/test/lib/sidekiq/test_unlock_ordering.rb
+++ b/test/lib/sidekiq/test_unlock_ordering.rb
@@ -1,0 +1,63 @@
+require 'helper'
+require 'sidekiq/worker'
+require 'sidekiq-unique-jobs/middleware/server/unique_jobs'
+
+class TestUnlockOrdering < MiniTest::Unit::TestCase
+  QUEUE = 'unlock_ordering'
+
+  class BeforeYieldOrderingWorker
+    include Sidekiq::Worker
+
+    sidekiq_options unique: true, unique_unlock_order: :before_yield, queue: QUEUE
+
+    def perform
+    end
+  end
+
+  class AfterYieldOrderingWorker
+    include Sidekiq::Worker
+
+    sidekiq_options unique: true, unique_unlock_order: :after_yield, queue: QUEUE
+
+    def perform
+    end
+  end
+
+  describe 'with real redis' do
+    before do
+      Sidekiq.redis = REDIS
+      Sidekiq.redis { |c| c.flushdb }
+      @middleware = SidekiqUniqueJobs::Middleware::Server::UniqueJobs.new
+    end
+
+    describe ':before_yield' do
+      it 'removes the lock before yielding to the worker' do
+        jid = BeforeYieldOrderingWorker.perform_async
+        item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
+
+        result = @middleware.call(BeforeYieldOrderingWorker.new, item, QUEUE) do
+          Sidekiq.redis do |c|
+            c.get(SidekiqUniqueJobs::PayloadHelper.get_payload(item['class'], item['queue'], item['args']))
+          end
+        end
+
+        assert_nil result
+      end
+    end
+
+    describe ':after_yield' do
+      it 'removes the lock after yielding to the worker' do
+        jid = AfterYieldOrderingWorker.perform_async
+        item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
+
+        result = @middleware.call(AfterYieldOrderingWorker.new, item, QUEUE) do
+          Sidekiq.redis do |c|
+            c.get(SidekiqUniqueJobs::PayloadHelper.get_payload(item['class'], item['queue'], item['args']))
+          end
+        end
+
+        assert_equal '1', result
+      end
+    end
+  end
+end


### PR DESCRIPTION
First of all, thanks for writing this gem. We ran into a situation where we wanted to expire locks before the server middleware yields. This PR would make the ordering configurable. I wasn't too sure about how to name the option parameters, but I hope they are fine.
