### PR TITLE
Don't connect to Redis when sidekiq/testing is loaded

### DIFF
--- a/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
+++ b/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
@@ -4,49 +4,50 @@ module SidekiqUniqueJobs
   module Middleware
     module Client
       class UniqueJobs
+        attr_reader :item, :worker_class
+
         def call(worker_class, item, queue)
+          @worker_class = worker_class_constantize(worker_class)
+          @item = item
 
-          klass = worker_class_constantize(worker_class)
-
-          enabled = klass.get_sidekiq_options['unique'] || item['unique']
-          unique_job_expiration = klass.get_sidekiq_options['unique_job_expiration']
-
-          if enabled
-
-            payload_hash = SidekiqUniqueJobs::PayloadHelper.get_payload(item['class'], item['queue'], item['args'])
-
-            unique = false
-
-            Sidekiq.redis do |conn|
-
-              conn.watch(payload_hash)
-
-              if conn.get(payload_hash).to_i == 1 || 
-                (conn.get(payload_hash).to_i == 2 && item['at'])
-                # if the job is already queued, or is already scheduled and 
-                # we're trying to schedule again, abort 
-                conn.unwatch
-              else
-                # if the job was previously scheduled and is now being queued,
-                # or we've never seen it before
-                expires_at = unique_job_expiration || SidekiqUniqueJobs::Config.default_expiration
-                expires_at = ((Time.at(item['at']) - Time.now.utc) + expires_at).to_i if item['at']
-
-                unique = conn.multi do
-                  # set value of 2 for scheduled jobs, 1 for queued jobs.
-                  conn.setex(payload_hash, expires_at, item['at'] ? 2 : 1)
-                end
-              end
-            end
-            yield if unique
+          if enabled?
+            yield if unique?
           else
             yield
           end
         end
 
+        def unique?
+          unique = false
+
+          Sidekiq.redis do |conn|
+
+            conn.watch(payload_hash)
+
+            if conn.get(payload_hash).to_i == 1 ||
+              (conn.get(payload_hash).to_i == 2 && item['at'])
+              # if the job is already queued, or is already scheduled and
+              # we're trying to schedule again, abort
+              conn.unwatch
+            else
+              # if the job was previously scheduled and is now being queued,
+              # or we've never seen it before
+              expires_at = unique_job_expiration || SidekiqUniqueJobs::Config.default_expiration
+              expires_at = ((Time.at(item['at']) - Time.now.utc) + expires_at).to_i if item['at']
+
+              unique = conn.multi do
+                # set value of 2 for scheduled jobs, 1 for queued jobs.
+                conn.setex(payload_hash, expires_at, item['at'] ? 2 : 1)
+              end
+            end
+          end
+
+          unique
+        end
+
         protected
 
-        # Attempt to constantize a string worker_class argument, always 
+        # Attempt to constantize a string worker_class argument, always
         # failing back to the original argument.
         def worker_class_constantize(worker_class)
           if worker_class.is_a?(String)
@@ -54,6 +55,32 @@ module SidekiqUniqueJobs
           else
             worker_class
           end
+        end
+
+        private
+
+        # If the worker or item is marked as unique and testing is not enabled,
+        # enable unique jobs.
+        def enabled?
+          unique_enabled? && !testing_enabled?
+        end
+
+        def payload_hash
+          SidekiqUniqueJobs::PayloadHelper.get_payload(item['class'], item['queue'], item['args'])
+        end
+
+        # When sidekiq/testing is loaded, the Sidekiq::Testing constant is
+        # present and testing is enabled.
+        def testing_enabled?
+          Sidekiq.const_defined?('Testing') && Sidekiq::Testing.enabled?
+        end
+
+        def unique_enabled?
+          worker_class.get_sidekiq_options['unique'] || item['unique']
+        end
+
+        def unique_job_expiration
+          worker_class.get_sidekiq_options['unique_job_expiration']
         end
 
       end

--- a/sidekiq-unique-jobs.gemspec
+++ b/sidekiq-unique-jobs.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      'rake'
   gem.add_development_dependency      'activesupport', '~> 3'
   gem.add_development_dependency      'simplecov'
+  gem.add_development_dependency      'mocha'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,6 +6,7 @@ end
 require 'minitest/unit'
 require 'minitest/pride'
 require 'minitest/autorun'
+require 'mocha'
 
 require 'sidekiq-unique-jobs'
 require "sidekiq"
@@ -14,3 +15,7 @@ Sidekiq.logger.level = Logger::ERROR
 
 require 'sidekiq/redis_connection'
 REDIS = Sidekiq::RedisConnection.create(:url => "redis://localhost/15", :namespace => 'testy')
+
+require 'sidekiq/testing'
+# Disable testing or all specs fail since they depend on connecting to Redis.
+Sidekiq::Testing.disable!


### PR DESCRIPTION
When sidekiq/testing is loaded, Sidekiq doesn't attempt to connect to Redis, so it isn't required to be running when tests/specs are run (see #18). Since unique jobs checking is dependent on connecting to Redis, it either needs to be mocked or disabled during spec runs. This cut simply disables unique job checking when `Sidekiq::Testing` is enabled.

The tests were a bit tricky to setup, so I ended breaking up the the `#call` method into several smaller methods including a `#unique?` predicate method that handles checking if the job being queued is unique. The test helper now loads sidekiq/testing and I added Mocha as a development dependency to provide testing coverage for this new functionality.

The specs are passing, so assuming this follows your coding standards and the general spirit of the library, it should be good to go. Just let me know if you'd like anything changed.
