### PR TITLE
Add option to make jobs unique on all queues

### DIFF
--- a/lib/sidekiq-unique-jobs/payload_helper.rb
+++ b/lib/sidekiq-unique-jobs/payload_helper.rb
@@ -1,13 +1,18 @@
 module SidekiqUniqueJobs
   class PayloadHelper
     def self.get_payload(klass, queue, *args)
-      args = yield_unique_args(klass, *args) if SidekiqUniqueJobs::Config.unique_args_enabled?
-      md5_arguments = {:class => klass, :queue => queue, :args => args}
+      unique_on_all_queues = false
+      if SidekiqUniqueJobs::Config.unique_args_enabled?
+        worker_class = klass.constantize
+        args = yield_unique_args(worker_class, *args)
+        unique_on_all_queues = worker_class.get_sidekiq_options['unique_on_all_queues']
+      end
+      md5_arguments = {:class => klass, :args => args}
+      md5_arguments[:queue] = queue unless unique_on_all_queues
       "#{SidekiqUniqueJobs::Config.unique_prefix}:#{Digest::MD5.hexdigest(Sidekiq.dump_json(md5_arguments))}"
     end
 
-    def self.yield_unique_args(klass, args)
-      worker_class = klass.constantize
+    def self.yield_unique_args(worker_class, args)
       unique_args = worker_class.get_sidekiq_options['unique_args']
       filtered_args = if unique_args
                         case unique_args


### PR DESCRIPTION
We process jobs on a priority queue and a default queue; but they are the same kinds of jobs, and if its already on one queue, we don't want it on another.

So, being able to ignore the queue would be really useful. This pull adds an option that, when unique_args are enabled, allows a `unique_on_all_queues` option to be added.
