### PR TITLE
Clarify README about unique expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ sidekiq_options unique: true
 ```
 
 For jobs scheduled in the future it is possible to set for how long the job
-should be unique. The job will be unique for the number of seconds configured
-or until the job has been completed.
+should be unique. The job will be unique for the number of seconds configured (default 30 minutes)
+or until the job has been completed. Thus, the job will be unique for the shorter of the two.  Note that Sidekiq versions before 3.0 will remove job keys after an hour, which means jobs can remain unique for at most an hour.
 
 *If you want the unique job to stick around even after it has been successfully
 processed then just set the unique_unlock_order to anything except `:before_yield` or `:after_yield` (`unique_unlock_order = :never`)


### PR DESCRIPTION
I wanted to make sure I understood how long the uniqueness of a job lasts and, if my observation is correct, update the README accordingly. 

I'm confident that the job will be unique for the shorter of the seconds configured or seconds for the job to complete. See: https://github.com/mhenrixon/sidekiq-unique-jobs/blob/master/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb#L47

I'm less confident about my observation with Sidekiq versions before 3.0, but I'm pretty sure it's the reason why my long running jobs do not remain unique. See: https://github.com/mperham/sidekiq/issues/1508#issuecomment-37523281 and https://github.com/mperham/sidekiq/blob/20b7a4fe47585ce9c43981305d146bd087540bbf/lib/sidekiq/web_helpers.rb#L50-L83

Thanks!
