### PR TITLE
Fix repo URLs for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SidekiqUniqueJobs [![Build Status](https://travis-ci.org/form26/sidekiq-unique-jobs.png?branch=master)](https://travis-ci.org/form26/sidekiq-unique-jobs) [![Code Climate](https://codeclimate.com/github/form26/sidekiq-unique-jobs.png)](https://codeclimate.com/github/form26/sidekiq-unique-jobs)
+# SidekiqUniqueJobs [![Build Status](https://travis-ci.org/mhenrixon/sidekiq-unique-jobs.png?branch=master)](https://travis-ci.org/mhenrixon/sidekiq-unique-jobs) [![Code Climate](https://codeclimate.com/github/mhenrixon/sidekiq-unique-jobs.png)](https://codeclimate.com/github/mhenrixon/sidekiq-unique-jobs)
 
 The missing unique jobs for sidekiq
 


### PR DESCRIPTION
The badges were still referencing the github user form26.
