### PR TITLE
Add the unique hash to the message for use by the workers.

### DIFF
--- a/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
+++ b/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
@@ -12,6 +12,7 @@ module SidekiqUniqueJobs
           @item = item
 
           if unique_enabled?
+            @item['unique_hash'] = payload_hash
             yield if unique?
           else
             yield

--- a/spec/lib/sidekiq_testing_enabled_spec.rb
+++ b/spec/lib/sidekiq_testing_enabled_spec.rb
@@ -17,6 +17,14 @@ describe "When Sidekiq::Testing is enabled" do
         UniqueWorker.perform_async(param)
         expect(UniqueWorker.jobs.size).to eq(1)
       end
+
+      it "adds the unique_hash to the message" do
+        param = 'hash'
+        hash = SidekiqUniqueJobs::PayloadHelper.get_payload(UniqueWorker, :working, [param])
+        UniqueWorker.perform_async(param)
+        expect(UniqueWorker.jobs.size).to eq(1)
+        expect(UniqueWorker.jobs.first['unique_hash']).to eq(hash)
+      end
     end
 
     context "with non-unique worker" do


### PR DESCRIPTION
This adds the unique hash to the item message so that workers can access the information and remove the unique key on completion. This will allow go-workers to work with sidekiq-unique-jobs.

Fixes #40
