### PR TITLE
Fix dependency error in inline testing connector

### DIFF
--- a/lib/sidekiq-unique-jobs/middleware/client/connectors/testing_inline.rb
+++ b/lib/sidekiq-unique-jobs/middleware/client/connectors/testing_inline.rb
@@ -1,4 +1,5 @@
 require 'sidekiq-unique-jobs/middleware/client/connectors/connector'
+require 'sidekiq-unique-jobs/middleware/server/unique_jobs'
 
 module SidekiqUniqueJobs
   module Middleware


### PR DESCRIPTION
After require the new version 3.0.3,  I detected a dependency error in the testing_inline connector. 
