### PR TITLE
Use redis connections in a thread-safe way

### DIFF
--- a/lib/sidekiq_unique_jobs/connectors.rb
+++ b/lib/sidekiq_unique_jobs/connectors.rb
@@ -6,10 +6,11 @@ module SidekiqUniqueJobs
   module Connectors
     CONNECTOR_TYPES = [Testing, RedisPool, SidekiqRedis]
 
-    def self.conn(redis_pool = nil)
+    def self.with_connection(redis_pool = nil)
       CONNECTOR_TYPES.each do |connector|
-        conn = connector.conn(redis_pool)
-        return conn if conn
+        connector.with_connection(redis_pool) do |connection|
+          return yield(connection)
+        end
       end
     end
   end

--- a/lib/sidekiq_unique_jobs/connectors/redis_pool.rb
+++ b/lib/sidekiq_unique_jobs/connectors/redis_pool.rb
@@ -1,9 +1,9 @@
 module SidekiqUniqueJobs
   module Connectors
     class RedisPool
-      def self.conn(redis_pool = nil)
+      def self.with_connection(redis_pool = nil, &block)
         return if redis_pool.nil?
-        redis_pool.with { |conn| conn }
+        redis_pool.with(&block)
       end
     end
   end

--- a/lib/sidekiq_unique_jobs/connectors/sidekiq_redis.rb
+++ b/lib/sidekiq_unique_jobs/connectors/sidekiq_redis.rb
@@ -1,8 +1,8 @@
 module SidekiqUniqueJobs
   module Connectors
     class SidekiqRedis
-      def self.conn(_redis_pool = nil)
-        Sidekiq.redis { |conn| conn }
+      def self.with_connection(_redis_pool = nil, &block)
+        Sidekiq.redis(&block)
       end
     end
   end

--- a/lib/sidekiq_unique_jobs/connectors/testing.rb
+++ b/lib/sidekiq_unique_jobs/connectors/testing.rb
@@ -1,9 +1,9 @@
 module SidekiqUniqueJobs
   module Connectors
     class Testing
-      def self.conn(_redis_pool = nil)
+      def self.with_connection(_redis_pool = nil)
         return unless SidekiqUniqueJobs.config.testing_enabled?
-        SidekiqUniqueJobs.redis_mock { |conn| conn }
+        yield(SidekiqUniqueJobs.redis_mock)
       end
     end
   end

--- a/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
+++ b/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
@@ -53,15 +53,15 @@ module SidekiqUniqueJobs
         end
 
         def unlock(payload_hash)
-          conn.del(payload_hash)
+          with_connection { |conn| conn.del(payload_hash) }
         end
 
         def logger
           Sidekiq.logger
         end
 
-        def conn
-          SidekiqUniqueJobs::Connectors.conn(redis_pool)
+        def with_connection(&block)
+          SidekiqUniqueJobs::Connectors.with_connection(redis_pool, &block)
         end
       end
     end


### PR DESCRIPTION
Sidekiq's connection pool expects to be used as follows:

``` ruby
connection_pool.with do |connection|
  # do something with the connection
end
# dont use the connection any more!
```

Using the connection after the end of the block means that connections will be shared across threads. This can cause deadlocks.

I couldn't see a great way to write a test for this. Existing tests pass.
