### PR TITLE
Checking Sidekiq::Testing.inline? on testing strategy and connector

### DIFF
--- a/lib/sidekiq_unique_jobs/config.rb
+++ b/lib/sidekiq_unique_jobs/config.rb
@@ -30,8 +30,8 @@ module SidekiqUniqueJobs
       end
     end
 
-    def testing_enabled?
-      if Sidekiq.const_defined?('Testing') && Sidekiq::Testing.enabled?
+    def inline_testing_enabled?
+      if Sidekiq.const_defined?('Testing') && Sidekiq::Testing.enabled? && Sidekiq::Testing.inline?
         require 'sidekiq_unique_jobs/testing'
         return true
       end

--- a/lib/sidekiq_unique_jobs/connectors/testing.rb
+++ b/lib/sidekiq_unique_jobs/connectors/testing.rb
@@ -2,7 +2,7 @@ module SidekiqUniqueJobs
   module Connectors
     class Testing
       def self.connection(_redis_pool = nil)
-        return unless SidekiqUniqueJobs.config.testing_enabled?
+        return unless SidekiqUniqueJobs.config.inline_testing_enabled?
         yield SidekiqUniqueJobs.redis_mock
         true
       end

--- a/lib/sidekiq_unique_jobs/middleware/client/strategies/testing_inline.rb
+++ b/lib/sidekiq_unique_jobs/middleware/client/strategies/testing_inline.rb
@@ -6,7 +6,7 @@ module SidekiqUniqueJobs
       module Strategies
         class TestingInline < Unique
           def self.elegible?
-            SidekiqUniqueJobs.config.testing_enabled? && Sidekiq::Testing.inline?
+            SidekiqUniqueJobs.config.inline_testing_enabled?
           end
 
           def review

--- a/spec/lib/sidekiq_testing_enabled_spec.rb
+++ b/spec/lib/sidekiq_testing_enabled_spec.rb
@@ -3,6 +3,7 @@ require 'sidekiq/worker'
 require 'sidekiq-unique-jobs'
 require 'sidekiq/scheduled'
 require 'sidekiq_unique_jobs/middleware/server/unique_jobs'
+require 'active_support/core_ext/time'
 require 'active_support/testing/time_helpers'
 require 'rspec-sidekiq'
 


### PR DESCRIPTION
When checking the testing strategy's `eligible?` method the `Sidekiq::Testing.inline?` was being checked, but not on the testing connector.

This caused mock_redis to be required even when inline testing was not being used.

Should fix #71