### PR TITLE
Exception when setex ttl param < 0

### DIFF
--- a/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
+++ b/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
@@ -50,8 +50,9 @@ module SidekiqUniqueJobs
             connection do |conn|
               conn.watch(payload_hash)
 
-              if conn.get(payload_hash).to_i == 1 ||
-                 (conn.get(payload_hash).to_i == 2 && item['at'])
+              perform_schedule = conn.get(payload_hash).to_i
+              if perform_schedule == 1 ||
+                 (perform_schedule == 2 && item['at'])
                 # if the job is already queued, or is already scheduled and
                 # we're trying to schedule again, abort
                 conn.unwatch


### PR DESCRIPTION
The ```get(payload_hash)``` change is generally useful, but I think the setex change may be a non-issue.

I came across it when trying to have a job maintain runtime uniqueness but also reschedule itself. I addressed that by bouncing uniqueness between two workers and tried to be clever with my FutureWorker by setting ```unique_job_expiration: 0.seconds``` before I found the ```unique_unlock_order: :before_yield``` option.

btw I had started this fork and pr also thinking that someone may try to perform_in with a date-like interval < Time.now, but in developing it I found this code in Sidekiq::Worker.perform_in in sidekiq-3.1.4
```ruby
        # Optimization to enqueue something now that is scheduled to go out now or in the past
        item.delete('at') if ts <= now
```
So sidekiq coincidentally protects sidekiq-unique-jobs from ever calling setex with ttl < 1 as long as ```unique_job_expiration > 0``` (or falsy and ```SidekiqUniqueJobs.config.default_expiration > 0```)

deferring to discussion in #72 for a best solution to "allow jobs to reschedule themselves in the future, but retain runtime uniqueness"