### PR TITLE
Remove no-op code, protect global space from test code

### DIFF
--- a/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
+++ b/lib/sidekiq_unique_jobs/middleware/server/unique_jobs.rb
@@ -12,13 +12,11 @@ module SidekiqUniqueJobs
 
           decide_unlock_order(worker.class)
           lock_key = payload_hash(item)
-          unlocked = before_yield? ? unlock(lock_key).inspect : 0
+          unlock(lock_key) if before_yield?
 
           yield
         ensure
-          if after_yield? || !defined? unlocked || unlocked != 1
-            unlock(lock_key)
-          end
+          unlock(lock_key) if after_yield?
         end
 
         def decide_unlock_order(klass)

--- a/spec/lib/middleware/server/unique_jobs_spec.rb
+++ b/spec/lib/middleware/server/unique_jobs_spec.rb
@@ -20,8 +20,10 @@ module SidekiqUniqueJobs
           end
 
           it 'returns true when unique_unlock_order has been set' do
-            UniqueWorker.sidekiq_options unique_unlock_order: :before_yield
-            expect(subject.unlock_order_configured?(UniqueWorker))
+            test_worker_class = UniqueWorker.dup
+            test_worker_class.sidekiq_options unique_unlock_order: :before_yield
+
+            expect(subject.unlock_order_configured?(test_worker_class))
               .to eq(true)
           end
         end
@@ -29,9 +31,11 @@ module SidekiqUniqueJobs
         describe '#decide_unlock_order' do
           context 'when worker has specified unique_unlock_order' do
             it 'changes unlock_order to the configured value' do
-              UniqueWorker.sidekiq_options unique_unlock_order: :before_yield
+              test_worker_class = UniqueWorker.dup
+              test_worker_class.sidekiq_options unique_unlock_order: :before_yield
+
               expect do
-                subject.decide_unlock_order(UniqueWorker)
+                subject.decide_unlock_order(test_worker_class)
               end.to change { subject.unlock_order }.to :before_yield
             end
           end
@@ -39,6 +43,7 @@ module SidekiqUniqueJobs
           context "when worker hasn't specified unique_unlock_order" do
             it 'falls back to configured default_unlock_order' do
               SidekiqUniqueJobs.config.default_unlock_order = :before_yield
+
               expect do
                 subject.decide_unlock_order(UniqueWorker)
               end.to change { subject.unlock_order }.to :before_yield


### PR DESCRIPTION
I'm working on a different PR (that's potentially contentious) and found some accidentally-working code.

Maybe middleware/sever/unique_jobs.rb#call was intended to release the lock if
1) an exception was raised
2) before_yield? was true but redis failed to delete the key.

However,

```(unlocked != 1)``` will always be true because (without exceptions) ```unlocked``` will either be integer ```0``` or string ```"1"``` or maybe string ```"\"1\""``` because of the call to ```.inspect()```

This code happened to to leave the lock in place if ```option['unique_unlock_order'] == :never``` because ```!defined? unlocked || unlocked != 1``` is the same as ``` !defined?(unlocked || unlocked != 1)``` not ``` !defined?(unlocked) || (unlocked != 1)```

I spent some time thinking about how to write a test case to demonstrate, but I think that may not be possible since even if I stub one of the methods before the ```unlocked``` assignment to raise, ```unlocked``` is still a defined local_variable.

If the design was to unlock on exception, then that logic ought to go into ```after_yield?``` with a side-effect from ```unlock(payload_hash)``` and maybe add a ```never_unlock?``` or ```always_unlock?``` method.


as for unique_jobs_spec.rb, "when get_sidekiq_options[:unique_unlock_order] is nil" has an order-dependency on being run before any ```.sidekiq_options unique_unlock_order: :before_yield``` etc so I made the tests clone UniqueWorker before modifying class_variables

