### PR TITLE
Do not unlock on sidekiq shutdown

### DIFF
--- a/spec/lib/middleware/server/unique_jobs_spec.rb
+++ b/spec/lib/middleware/server/unique_jobs_spec.rb
@@ -80,7 +80,7 @@ module SidekiqUniqueJobs
         describe '#call' do
           context 'unlock' do
             let(:uj) { SidekiqUniqueJobs::Middleware::Server::UniqueJobs.new }
-            let(:items) { [UniqueWorker.new, { 'class' => 'testClass' }, 'test'] }
+            let(:items) { [AfterYieldWorker.new, { 'class' => 'testClass' }, 'test'] }
 
             it 'should unlock after yield when call succeeds' do
               expect(uj).to receive(:unlock)

--- a/spec/lib/middleware/server/unique_jobs_spec.rb
+++ b/spec/lib/middleware/server/unique_jobs_spec.rb
@@ -80,22 +80,24 @@ module SidekiqUniqueJobs
         describe '#call' do
           context 'unlock' do
             let(:uj) { SidekiqUniqueJobs::Middleware::Server::UniqueJobs.new }
+            let(:items) { [UniqueWorker.new, { 'class' => 'testClass' }, 'test'] }
+
             it 'should unlock after yield when call succeeds' do
               expect(uj).to receive(:unlock)
 
-              uj.call(UniqueWorker.new, { 'class' => 'testClass' }, 'test') { true }
+              uj.call(*items) { true }
             end
 
             it 'should unlock after yield when call errors' do
               expect(uj).to receive(:unlock)
 
-              expect{ uj.call(UniqueWorker.new, { 'class' => 'testClass' }, 'test') { raise } }.to raise_error(RuntimeError)
+              expect { uj.call(*items) { fail } }.to raise_error(RuntimeError)
             end
 
             it 'should not unlock after yield on shutdown, but still raise error' do
               expect(uj).to_not receive(:unlock)
 
-              expect{ uj.call(UniqueWorker.new, { 'class' => 'testClass' }, 'test') { raise Sidekiq::Shutdown } }.to raise_error(Sidekiq::Shutdown)
+              expect { uj.call(*items) { fail Sidekiq::Shutdown } }.to raise_error(Sidekiq::Shutdown)
             end
           end
         end

--- a/spec/support/after_yield_worker.rb
+++ b/spec/support/after_yield_worker.rb
@@ -1,6 +1,6 @@
 class AfterYieldWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :working, retry: 1, backtrace: 10, after_yield: true
+  sidekiq_options queue: :working, retry: 1, backtrace: 10, unique_unlock_order: :after_yield
   sidekiq_options unique: false
 
   sidekiq_retries_exhausted do |msg|

--- a/spec/support/after_yield_worker.rb
+++ b/spec/support/after_yield_worker.rb
@@ -1,0 +1,13 @@
+class AfterYieldWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :working, retry: 1, backtrace: 10, after_yield: true
+  sidekiq_options unique: false
+
+  sidekiq_retries_exhausted do |msg|
+    Sidekiq.logger.warn "Failed #{msg['class']} with #{msg['args']}: #{msg['error_message']}"
+  end
+
+  def perform(*)
+    # NO-OP
+  end
+end


### PR DESCRIPTION
somewhat related to https://github.com/mhenrixon/sidekiq-unique-jobs/issues/77

The current behavior of sidekiq-unique-jobs is to unlock a job when job is done regardless of if the job succeeds or fails.  From what I can tell this is desired because sidekiq requeues failed jobs and sidekiq-unique-jobs would otherwise prevent them from being queued.

There is one exception and that is when a task is killed due to exceeding a timeout during a worker shutdown. [https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/processor.rb#L55-L59](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/processor.rb#L55-L59)  In that case the job is left and the worker picks it back up when it restarts.  The task kill generates an exception and sidekiq-unique-job removes the lock even though the job is still there. When the worker starts again it picks up the job again, but non-unique work can be queued because the lock was already removed. 

This PR duplicates the logic of the sidekiq processor to also catch the shutdown exception and not unlock the job in that case.

I first noticed this when having a unique reoccurring task that took longer than the reoccurrence (ran for 100 seconds, but started every minute) If the worker was restarted while the task was running it would start up again and at the top of the next minute a duplicate task would start. When the first task would complete it would unlock the lock placed by the second task and the two jobs would leapfrog forever. 