### PR TITLE
Prevent Jobs from deleting mutexes they don't own

### DIFF
--- a/lib/sidekiq_unique_jobs/inline_testing.rb
+++ b/lib/sidekiq_unique_jobs/inline_testing.rb
@@ -1,3 +1,5 @@
+require 'sidekiq_unique_jobs/lib'
+
 begin
   require 'mock_redis'
 rescue LoadError

--- a/lib/sidekiq_unique_jobs/lib.rb
+++ b/lib/sidekiq_unique_jobs/lib.rb
@@ -1,0 +1,23 @@
+require 'pry-byebug'
+module SidekiqUniqueServerLib
+  def remove_if_matches
+    <<-LUA
+      if redis.call('GET', KEYS[1]) == ARGV[1] then
+        redis.call('DEL', KEYS[1])
+      end
+    LUA
+  end
+end
+
+module SidekiqUniqueServerMockLib
+  def unlock(lock_key, item)
+    connection do |con|
+      con.watch(lock_key)
+      if con.get(lock_key) == item['jid']
+        ret = con.multi { con.del(lock_key) }
+      else
+        con.unwatch
+      end
+    end
+  end
+end

--- a/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
+++ b/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
@@ -66,7 +66,7 @@ module SidekiqUniqueJobs
               else
                 unique = conn.multi do
                   # set value of 2 for scheduled jobs, 1 for queued jobs.
-                  conn.setex(payload_hash, expires_at, item['at'] ? 2 : 1)
+                  conn.setex(payload_hash, expires_at, item['jid'])
                 end
               end
             end
@@ -75,7 +75,7 @@ module SidekiqUniqueJobs
 
           def new_unique_for?
             connection do |conn|
-              return conn.set(payload_hash, item['at'] ? 2 : 1, nx: true, ex: expires_at)
+              return conn.set(payload_hash, item['jid'], nx: true, ex: expires_at)
             end
           end
 

--- a/spec/lib/sidekiq_testing_enabled_spec.rb
+++ b/spec/lib/sidekiq_testing_enabled_spec.rb
@@ -8,6 +8,8 @@ require 'active_support/testing/time_helpers'
 require 'rspec-sidekiq'
 
 describe 'When Sidekiq::Testing is enabled' do
+  SidekiqUniqueJobs::Middleware::Server::UniqueJobs.prepend(SidekiqUniqueServerMockLib)
+
   describe 'when set to :fake!', sidekiq: :fake do
     before do
       Sidekiq.redis = REDIS

--- a/spec/lib/sidekiq_unique_ext_spec.rb
+++ b/spec/lib/sidekiq_unique_ext_spec.rb
@@ -14,6 +14,16 @@ class JustAWorker
   end
 end
 
+class Sidekiq::Job
+  def _sidekiq_redis
+    Sidekiq.redis do |con|
+      yield con
+    end
+  end
+  include SidekiqUniqueServerMockLib
+  alias_method :connection, :_sidekiq_redis
+end
+
 describe Sidekiq::Job::UniqueExtension do
   before do
     Sidekiq.redis = REDIS


### PR DESCRIPTION
Hello - so this should solve #94. The jid should already be sufficiently unique for each job and both server and client middleware have access to this. 

Using the LUA script would be preferable since it saves a back-and-forth trip to the server, but if there users of sidekiq-unique-jobs with old versions of redis -- perhaps it would make sense to use the conn.watch version by default. (It's included for the tests anyways since mock-redis does not support lua scripts). 