### PR TITLE
Add run_lock to prevent duplicate running jobs

### DIFF
--- a/lib/sidekiq-unique-jobs.rb
+++ b/lib/sidekiq-unique-jobs.rb
@@ -16,7 +16,12 @@ module SidekiqUniqueJobs
       default_expiration: 30 * 60,
       default_unlock_order: :after_yield,
       unique_storage_method: :new,
-      redis_test_mode: :redis # :mock
+      redis_test_mode: :redis, # :mock
+      default_run_lock: false,
+      default_run_lock_retry_interval: 0,
+      default_run_lock_retries: 0,
+      default_reschedule_on_lock_fail: false,
+      default_run_lock_expire: 60
     )
   end
 

--- a/lib/sidekiq_unique_jobs/config.rb
+++ b/lib/sidekiq_unique_jobs/config.rb
@@ -6,7 +6,12 @@ module SidekiqUniqueJobs
       :default_expiration,
       :default_unlock_order,
       :unique_storage_method,
-      :redis_mode
+      :redis_mode,
+      :default_run_lock,
+      :default_run_lock_retry_interval,
+      :default_run_lock_retries,
+      :default_reschedule_on_lock_fail,
+      :default_run_lock_expire
     ]
 
     class << self

--- a/lib/sidekiq_unique_jobs/exception.rb
+++ b/lib/sidekiq_unique_jobs/exception.rb
@@ -1,0 +1,3 @@
+module SidekiqUniqueJobs
+  class RunLockFailedError < StandardError; end
+end

--- a/lib/sidekiq_unique_jobs/server/middleware.rb
+++ b/lib/sidekiq_unique_jobs/server/middleware.rb
@@ -7,45 +7,82 @@ module SidekiqUniqueJobs
     class Middleware
       include Extensions
 
-      attr_reader :unlock_order, :redis_pool
+      attr_reader :unlock_order,
+                  :redis_pool,
+                  :reschedule_on_lock_fail,
+                  :run_lock_retries,
+                  :run_lock_retry_interval
 
-      def call(worker, item, _queue, redis_pool = nil)
-        operative = true
+      def call(worker, item, _queue, redis_pool = nil, &blk)
         @redis_pool = redis_pool
-        decide_unlock_order(worker.class)
+        setup_options(worker.class)
+        send("#{unlock_order}_call", item, &blk)
+      end
+
+      def run_lock_call(item)
         lock_key = payload_hash(item)
-        unlock(lock_key, item) if before_yield?
+        run_lock = try_acquire_run_lock(lock_key, item)
+        if run_lock
+          unlock(lock_key, item)
+          yield
+        else
+          if reschedule_on_lock_fail
+            reschedule(item)
+          else # Not sure if we want to raise?
+            raise SidekiqUniqueJobs::RunLockFailedError
+          end
+        end
+      ensure
+        if run_lock
+          unlock_run(lock_key, item)
+        end
+      end
+
+      def before_yield_call(item)
+        unlock(payload_hash(item), item)
+        yield
+      end
+
+      def after_yield_call(item)
+        operative = true
         yield
       rescue Sidekiq::Shutdown
         operative = false
         raise
       ensure
-        unlock(lock_key, item) if after_yield? && operative
+        unlock(payload_hash(item), item) if operative
       end
 
-      def decide_unlock_order(klass)
-        @unlock_order = if unlock_order_configured?(klass)
-                          klass.get_sidekiq_options['unique_unlock_order']
-                        else
-                          default_unlock_order
-                        end
+      def never_call(*)
+        yield if block_given?
       end
 
-      def unlock_order_configured?(klass)
-        klass.respond_to?(:get_sidekiq_options) &&
-          !klass.get_sidekiq_options['unique_unlock_order'].nil?
+      def options
+        @options ||= {}
       end
 
-      def default_unlock_order
-        SidekiqUniqueJobs.config.default_unlock_order
+      def setup_options(klass)
+        @options = klass.get_sidekiq_options if klass.respond_to?(:get_sidekiq_options)
       end
 
-      def before_yield?
-        unlock_order == :before_yield
+      def unlock_order
+        options['unique_unlock_order'] || SidekiqUniqueJobs.config.default_unlock_order
       end
 
-      def after_yield?
-        unlock_order == :after_yield
+      def reschedule_on_lock_fail
+        options['reschedule_on_lock_fail'] || SidekiqUniqueJobs.config.default_reschedule_on_lock_fail
+      end
+
+      def run_lock_retries
+        options['run_lock_retries'] || SidekiqUniqueJobs.config.default_run_lock_retries
+      end
+
+      def run_lock_retry_interval
+        options['run_lock_retry_interval'] || SidekiqUniqueJobs.config.default_run_lock_retry_interval
+      end
+
+      def run_lock_expire
+        options['run_lock_expire'] || SidekiqUniqueJobs.config.default_run_lock_expire
       end
 
       protected
@@ -66,6 +103,31 @@ module SidekiqUniqueJobs
 
       def connection(&block)
         SidekiqUniqueJobs::Connectors.connection(redis_pool, &block)
+      end
+
+      def unlock_run(lock_key, item)
+        connection do |con|
+          con.eval(remove_on_match, keys: ["#{lock_key}:run"], argv: [item['jid']])
+        end
+      end
+
+      def reschedule(item)
+        Sidekiq::Client.new(redis_pool).raw_push([item])
+      end
+
+      def try_acquire_run_lock(lock_key, item)
+        status = begin
+          (run_lock_retries + 1).times do
+            status = connection do |con|
+              con.set("#{lock_key}:run", item['jid'], nx: true, ex: run_lock_expire)
+            end
+            break if status
+            sleep(run_lock_retry_interval)
+          end
+          status
+        rescue Redis::ConnectionError, Redis::TimeoutError
+          # Don't say I didn't warn you about spinlocks
+        end
       end
     end
   end

--- a/spec/lib/server/middleware_spec.rb
+++ b/spec/lib/server/middleware_spec.rb
@@ -6,25 +6,9 @@ module SidekiqUniqueJobs
     describe Middleware do
       describe '#unlock_order_configured?' do
         context "when class isn't a Sidekiq::Worker" do
-          it 'returns false' do
-            expect(subject.unlock_order_configured?(Class))
-              .to eq(false)
+          it 'class defaults are not set' do
+            expect(subject.setup_options(Class)).to eq(nil)
           end
-        end
-
-        context 'when get_sidekiq_options[:unique_unlock_order] is nil' do
-          it 'returns false' do
-            expect(subject.unlock_order_configured?(MyWorker))
-              .to eq(false)
-          end
-        end
-
-        it 'returns true when unique_unlock_order has been set' do
-          test_worker_class = UniqueWorker.dup
-          test_worker_class.sidekiq_options unique_unlock_order: :before_yield
-
-          expect(subject.unlock_order_configured?(test_worker_class))
-            .to eq(true)
         end
       end
 
@@ -34,50 +18,24 @@ module SidekiqUniqueJobs
             test_worker_class = UniqueWorker.dup
             test_worker_class.sidekiq_options unique_unlock_order: :before_yield
 
-            expect do
-              subject.decide_unlock_order(test_worker_class)
-            end.to change { subject.unlock_order }.to :before_yield
+            subject.setup_options(test_worker_class)
+            expect(subject.unlock_order).to eq :before_yield
           end
         end
 
         context "when worker hasn't specified unique_unlock_order" do
           it 'falls back to configured default_unlock_order' do
             SidekiqUniqueJobs.config.default_unlock_order = :before_yield
-
-            expect do
-              subject.decide_unlock_order(UniqueWorker)
-            end.to change { subject.unlock_order }.to :before_yield
+            subject.setup_options(UniqueWorker)
+            expect(subject.unlock_order).to eq :before_yield
           end
         end
       end
 
-      describe '#before_yield?' do
-        it 'returns unlock_order == :before_yield' do
+      describe 'on :after_yield' do
+        it '#after_yield_call is called' do
           allow(subject).to receive(:unlock_order).and_return(:after_yield)
-          expect(subject.before_yield?).to eq(false)
-
-          allow(subject).to receive(:unlock_order).and_return(:before_yield)
-          expect(subject.before_yield?).to eq(true)
-        end
-      end
-
-      describe '#after_yield?' do
-        it 'returns unlock_order == :before_yield' do
-          allow(subject).to receive(:unlock_order).and_return(:before_yield)
-          expect(subject.after_yield?).to eq(false)
-
-          allow(subject).to receive(:unlock_order).and_return(:after_yield)
-          expect(subject.after_yield?).to eq(true)
-        end
-      end
-
-      describe '#default_unlock_order' do
-        it 'returns the default value from config' do
-          SidekiqUniqueJobs.config.default_unlock_order = :before_yield
-          expect(subject.default_unlock_order).to eq(:before_yield)
-
-          SidekiqUniqueJobs.config.default_unlock_order = :after_yield
-          expect(subject.default_unlock_order).to eq(:after_yield)
+          #expect(subject.call).to call(:after_yield_call)
         end
       end
 

--- a/spec/lib/sidekiq_testing_enabled_spec.rb
+++ b/spec/lib/sidekiq_testing_enabled_spec.rb
@@ -162,10 +162,9 @@ describe 'When Sidekiq::Testing is enabled' do
       end
     end
 
-    it 'once the job is completed allows to run another one' do
+    it 'once the job is completed it unlocks so another one can be run' do
       expect(TestClass).to receive(:run).with('test')
-      InlineWorker.perform_async('test')
-      expect(TestClass).to receive(:run).with('test')
+      expect_any_instance_of(SidekiqUniqueJobs::Server::Middleware).to receive(:unlock).and_call_original
       InlineWorker.perform_async('test')
     end
 

--- a/spec/lib/unlock_order_spec.rb
+++ b/spec/lib/unlock_order_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'sidekiq/api'
 require 'sidekiq/worker'
 require 'sidekiq_unique_jobs/server/middleware'
+require 'sidekiq_unique_jobs/exception'
 
 describe 'Unlock order' do
   QUEUE = 'unlock_ordering'
@@ -25,6 +26,27 @@ describe 'Unlock order' do
 
     sidekiq_options unique: true, unique_unlock_order: :after_yield, queue: QUEUE
 
+    def perform
+    end
+  end
+
+  class RunLockOrderingWorker
+    include Sidekiq::Worker
+
+    sidekiq_options unique: true, unique_unlock_order: :run_lock, queue: QUEUE
+    def perform
+    end
+  end
+
+  class RunLockSpinningWorker
+    include Sidekiq::Worker
+
+    sidekiq_options unique: true,
+                    unique_unlock_order: :run_lock,
+                    queue: QUEUE,
+                    run_lock_retries: 10,
+                    run_lock_retry_interval: 0,
+                    reschedule_on_lock_fail: true
     def perform
     end
   end
@@ -53,17 +75,65 @@ describe 'Unlock order' do
       end
     end
 
+    describe ':run_lock' do
+      it 'should acquire run_lock before yielding if :run_lock is set' do
+        jid = RunLockOrderingWorker.perform_async
+        item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
+        result = @middleware.call(RunLockOrderingWorker.new, item, QUEUE) do
+          Sidekiq.redis do |c|
+            c.get("#{get_payload(item)}:run")
+          end
+        end
+        expect(result).to eq jid
+      end
+
+      it 'should raise if it could not acquire run_lock' do
+        jid = RunLockOrderingWorker.perform_async
+        item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
+        Sidekiq.redis do |c|
+          c.set("#{get_payload(item)}:run", "LOCKED_OUT")
+        end
+        expect {
+          @middleware.call(RunLockOrderingWorker.new, item, QUEUE) do
+            true
+          end
+        }.to raise_error SidekiqUniqueJobs::RunLockFailedError
+      end
+
+      it 'should spin_lock is run_lock_retries are set' do
+        jid = RunLockSpinningWorker.perform_async
+        item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
+        Sidekiq.redis do |c|
+          c.set("#{get_payload(item)}:run", "LOCKED_OUT")
+        end
+        expect(Sidekiq).to receive(:redis).exactly(11).times.and_call_original
+        @middleware.call(RunLockSpinningWorker.new, item, QUEUE) do
+          true
+        end
+      end
+
+      it 'should reschedule if reschedule on lock fail is set' do
+        jid = RunLockSpinningWorker.perform_async
+        item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
+        Sidekiq.redis do |c|
+          c.set("#{get_payload(item)}:run", "LOCKED_OUT")
+        end
+        expect_any_instance_of(Sidekiq::Client).to receive(:raw_push).with([item])
+        @middleware.call(RunLockSpinningWorker.new, item, QUEUE) do
+          true
+        end
+      end
+    end
+
     describe ':before_yield' do
       it 'removes the lock before yielding to the worker' do
         jid = BeforeYieldOrderingWorker.perform_async
         item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
-
         result = @middleware.call(BeforeYieldOrderingWorker.new, item, QUEUE) do
           Sidekiq.redis do |c|
             c.get(get_payload(item))
           end
         end
-
         expect(result).to eq nil
       end
     end

--- a/spec/lib/unlock_order_spec.rb
+++ b/spec/lib/unlock_order_spec.rb
@@ -91,20 +91,20 @@ describe 'Unlock order' do
         jid = RunLockOrderingWorker.perform_async
         item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
         Sidekiq.redis do |c|
-          c.set("#{get_payload(item)}:run", "LOCKED_OUT")
+          c.set("#{get_payload(item)}:run", 'LOCKED_OUT')
         end
-        expect {
+        expect do
           @middleware.call(RunLockOrderingWorker.new, item, QUEUE) do
             true
           end
-        }.to raise_error SidekiqUniqueJobs::RunLockFailedError
+        end.to raise_error SidekiqUniqueJobs::RunLockFailedError
       end
 
       it 'should spin_lock is run_lock_retries are set' do
         jid = RunLockSpinningWorker.perform_async
         item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
         Sidekiq.redis do |c|
-          c.set("#{get_payload(item)}:run", "LOCKED_OUT")
+          c.set("#{get_payload(item)}:run", 'LOCKED_OUT')
         end
         expect(Sidekiq).to receive(:redis).exactly(11).times.and_call_original
         @middleware.call(RunLockSpinningWorker.new, item, QUEUE) do
@@ -116,7 +116,7 @@ describe 'Unlock order' do
         jid = RunLockSpinningWorker.perform_async
         item = Sidekiq::Queue.new(QUEUE).find_job(jid).item
         Sidekiq.redis do |c|
-          c.set("#{get_payload(item)}:run", "LOCKED_OUT")
+          c.set("#{get_payload(item)}:run", 'LOCKED_OUT')
         end
         expect_any_instance_of(Sidekiq::Client).to receive(:raw_push).with([item])
         @middleware.call(RunLockSpinningWorker.new, item, QUEUE) do

--- a/spec/support/regular_worker.rb
+++ b/spec/support/regular_worker.rb
@@ -1,0 +1,12 @@
+class RegularWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :working, retry: 1, backtrace: 10
+
+  sidekiq_retries_exhausted do |msg|
+    Sidekiq.logger.warn "Failed #{msg['class']} with #{msg['args']}: #{msg['error_message']}"
+  end
+
+  def perform(*)
+    # NO-OP
+  end
+end


### PR DESCRIPTION
#72 This patch adds a `:run_lock` along side `:before_yield` and `:after_yield` unlock ordering. `:run_lock` should guarantee that only a single unique Job is ever running at one time - without preventing another job from being queued. The default run_lock options are as follows: 
```
      default_run_lock_retry_interval: 0,
      default_run_lock_retries: 0,
      default_reschedule_on_lock_fail: false,
      default_run_lock_expire: 60,
```
if reschedule_on_lock_fail is set the job will be pushed back into the queue (perhaps reschedule_in could also be an option to push it into the scheduled queue?). If run_lock_retries is set it will spin_lock for run_lock_retries after initially failing to acquire the lock with run_lock_retry_interval as the wait time between attempts (@tsubery). 

On failure to acquire a lock it will Raise a RunLockFailedError. I'm not sure if this is preferable to failing silently since if the job has Sidekiq `:retries` options set it will effectively reschedule anyways; but I do think that reschedule on lock fail should be done by SidekiqUniqueJobs rather than through bubbling an error up to the Sidekiq processor since the later will consume a retry attempt, which might not be intended.  
 