### PR TITLE
Readme note about requiring the test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ end
 
 ### Testing
 
+To enable the testing for `sidekiq-unique-jobs`, add `require 'sidekiq_unique_jobs/testing'` to your testing helper.
+
 SidekiqUniqueJobs uses mock_redis for inline testing. Due to complaints about having that as a runtime dependency it was made a development dependency so if you are relying on inline testing you will have to add `gem 'mock_redis'` to your Gemfile.
 
 ## Contributing

--- a/sidekiq-unique-jobs.gemspec
+++ b/sidekiq-unique-jobs.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.post_install_message = 'If you are relying on `mock_redis` you will now have to add' \
                              'gem "mock_redis" to your desired bundler group.'
-  gem.version       = SidekiqUniqueJobs::VERSION
+  gem.version = SidekiqUniqueJobs::VERSION
   gem.add_dependency 'sidekiq', '>= 2.6'
   gem.add_development_dependency 'mock_redis'
   gem.add_development_dependency 'rspec', '~> 3.1.0'

--- a/spec/lib/client/middleware_spec.rb
+++ b/spec/lib/client/middleware_spec.rb
@@ -41,15 +41,15 @@ describe SidekiqUniqueJobs::Client::Middleware do
 
     it 'does not push duplicate messages when configured for unique only' do
       QueueWorker.sidekiq_options unique: true
-      10.times { Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue',  'args' => [1, 2]) }
+      10.times { Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2]) }
       result = Sidekiq.redis { |c| c.llen('queue:customqueue') }
       expect(result).to eq 1
     end
 
     it 'does push duplicate messages to different queues' do
       QueueWorker.sidekiq_options unique: true
-      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue',  'args' => [1, 2])
-      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue2',  'args' => [1, 2])
+      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2])
+      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue2', 'args' => [1, 2])
       q1_length = Sidekiq.redis { |c| c.llen('queue:customqueue') }
       q2_length = Sidekiq.redis { |c| c.llen('queue:customqueue2') }
       expect(q1_length).to eq 1
@@ -83,7 +83,7 @@ describe SidekiqUniqueJobs::Client::Middleware do
     it 'sets an expiration when provided by sidekiq options' do
       one_hour_expiration = 60 * 60
       QueueWorker.sidekiq_options unique: true, unique_job_expiration: one_hour_expiration
-      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue',  'args' => [1, 2])
+      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2])
 
       payload_hash = SidekiqUniqueJobs.get_payload('QueueWorker', 'customqueue', [1, 2])
       actual_expires_at = Sidekiq.redis { |c| c.ttl(payload_hash) }
@@ -94,7 +94,7 @@ describe SidekiqUniqueJobs::Client::Middleware do
 
     it 'does push duplicate messages when not configured for unique only' do
       QueueWorker.sidekiq_options unique: false
-      10.times { Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue',  'args' => [1, 2]) }
+      10.times { Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2]) }
       expect(Sidekiq.redis { |c| c.llen('queue:customqueue') }).to eq 10
 
       result = Sidekiq.redis { |c| c.llen('queue:customqueue') }
@@ -156,8 +156,8 @@ describe SidekiqUniqueJobs::Client::Middleware do
         before { QueueWorker.sidekiq_options unique: true, unique_on_all_queues: true }
         before { QueueWorker.sidekiq_options unique: true }
         it 'does not push duplicate messages on different queues' do
-          Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue',  'args' => [1, 2])
-          Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue2',  'args' => [1, 2])
+          Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2])
+          Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue2', 'args' => [1, 2])
           q1_length = Sidekiq.redis { |c| c.llen('queue:customqueue') }
           q2_length = Sidekiq.redis { |c| c.llen('queue:customqueue2') }
           expect(q1_length).to eq 1
@@ -189,7 +189,7 @@ describe SidekiqUniqueJobs::Client::Middleware do
 
       QueueWorker.sidekiq_options unique: true, log_duplicate_payload: true
 
-      2.times { Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue',  'args' => [1, 2]) }
+      2.times { Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2]) }
       result = Sidekiq.redis { |c| c.llen('queue:customqueue') }
       expect(result).to eq 1
     end
@@ -199,7 +199,7 @@ describe SidekiqUniqueJobs::Client::Middleware do
 
       QueueWorker.sidekiq_options unique: true, log_duplicate_payload: false
 
-      2.times { Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue',  'args' => [1, 2]) }
+      2.times { Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2]) }
       result = Sidekiq.redis { |c| c.llen('queue:customqueue') }
       expect(result).to eq 1
     end


### PR DESCRIPTION
Thanks to the recent changes that better keep job uniqueness under retries, crashes, or shutdown we've switched to using the master branch for one of our production apps. However, I noticed some of our specs started to fail, and it seems that now we need to `require 'sidekiq_unique_jobs/testing'` in `spec_helper.rb` or equivalent. This just adds a not about that to the readme.