### PR TITLE
Revert broken fix and add failing specs

### DIFF
--- a/lib/sidekiq_unique_jobs/client/middleware.rb
+++ b/lib/sidekiq_unique_jobs/client/middleware.rb
@@ -63,8 +63,7 @@ module SidekiqUniqueJobs
 
       def new_unique_for?
         connection do |conn|
-          return (conn.set(payload_hash, item['jid'], nx: true, ex: expires_at) ||
-            conn.get(payload_hash) == item['jid'])
+          return conn.set(payload_hash, item['jid'], nx: true, ex: expires_at)
         end
       end
 

--- a/spec/lib/client/middleware_spec.rb
+++ b/spec/lib/client/middleware_spec.rb
@@ -71,10 +71,10 @@ describe SidekiqUniqueJobs::Client::Middleware do
 
     it 'enqueues previously scheduled job' do
       QueueWorker.sidekiq_options unique: true
-      jid = QueueWorker.perform_in(60 * 60, 1, 2)
+      QueueWorker.perform_in(60 * 60, [1, 2])
 
       # time passes and the job is pulled off the schedule:
-      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2], 'jid' => jid)
+      Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2])
 
       result = Sidekiq.redis { |c| c.llen('queue:customqueue') }
       expect(result).to eq 1

--- a/spec/lib/client/middleware_spec.rb
+++ b/spec/lib/client/middleware_spec.rb
@@ -33,9 +33,33 @@ describe SidekiqUniqueJobs::Client::Middleware do
     end
 
     describe 'when a job is already scheduled' do
-      before { MyUniqueWorker.perform_in(3600, 1) }
-      it 'rejects new jobs with the same argument' do
-        expect(MyUniqueWorker.perform_async(1)).to eq(nil)
+      before 'schedule a job' do
+        MyUniqueWorker.perform_in(3600, 1)
+      end
+
+      context '#old_unique_for' do
+
+        it 'rejects new scheduled jobs with the same argument' do
+          allow(SidekiqUniqueJobs.config).to receive(:unique_storage_method).and_return(:old)
+          expect(MyUniqueWorker.perform_in(1800, 1)).to eq(nil)
+        end
+
+        it 'will run a job in real time with the same arguments' do
+          allow(SidekiqUniqueJobs.config).to receive(:unique_storage_method).and_return(:old)
+          expect(MyUniqueWorker.perform_async(1)).not_to eq(nil)
+        end
+      end
+      context '#new_unique_for' do
+
+        it 'rejects new scheduled jobs with the same argument' do
+          allow(SidekiqUniqueJobs.config).to receive(:unique_storage_method).and_return(:new)
+          expect(MyUniqueWorker.perform_in(3600, 1)).to eq(nil)
+        end
+
+        it 'will run a job in real time with the same arguments' do
+          allow(SidekiqUniqueJobs.config).to receive(:unique_storage_method).and_return(:new)
+          expect(MyUniqueWorker.perform_async(1)).not_to eq(nil)
+        end
       end
     end
 
@@ -71,7 +95,7 @@ describe SidekiqUniqueJobs::Client::Middleware do
 
     it 'enqueues previously scheduled job' do
       QueueWorker.sidekiq_options unique: true
-      QueueWorker.perform_in(60 * 60, [1, 2])
+      QueueWorker.perform_in(60 * 60, 1, 2)
 
       # time passes and the job is pulled off the schedule:
       Sidekiq::Client.push('class' => QueueWorker, 'queue' => 'customqueue', 'args' => [1, 2])


### PR DESCRIPTION
Revert for #105 which did not fix anything.
Add failing specs to master then it would be preferable for everyone to know that the current Master is broken. 

(If this is not promptly being resolved #101 has been outstanding for a while now)  (Currently our application is on 3.0.13, which still has unresolved problems but not as bad as the current Head). 

