### PR TITLE
Calculate worker's unique args when a proc or a symbol is specified

### DIFF
--- a/lib/sidekiq_unique_jobs/unique_args.rb
+++ b/lib/sidekiq_unique_jobs/unique_args.rb
@@ -20,7 +20,7 @@ module SidekiqUniqueJobs
         @item = job
         @worker_class ||= worker_class_constantize(@item[CLASS_KEY])
         @item[UNIQUE_PREFIX_KEY] ||= unique_prefix
-        @item[UNIQUE_ARGS_KEY] ||= unique_args(@item[ARGS_KEY])
+        @item[UNIQUE_ARGS_KEY] = unique_args(@item[ARGS_KEY]) # SIC! Calculate unique_args unconditionally
         @item[UNIQUE_DIGEST_KEY] ||= unique_digest
       end
     end

--- a/spec/jobs/custom_queue_job_with_filter_method.rb
+++ b/spec/jobs/custom_queue_job_with_filter_method.rb
@@ -1,7 +1,7 @@
 class CustomQueueJobWithFilterMethod < CustomQueueJob
   sidekiq_options unique: :until_executed, unique_args: :args_filter
 
-  def self.args_filter(*args)
+  def self.args_filter(args)
     args.first
   end
 end

--- a/spec/jobs/custom_queue_job_with_filter_proc.rb
+++ b/spec/jobs/custom_queue_job_with_filter_proc.rb
@@ -2,9 +2,9 @@ class CustomQueueJobWithFilterProc < CustomQueueJob
   # slightly contrived example of munging args to the
   # worker and removing a random bit.
   sidekiq_options unique: :until_timeout,
-                  unique_args: (lambda do |*args|
+                  unique_args: (lambda do |args|
                     options = args.extract_options!
-                    options.delete(:random)
-                    [args, options]
+                    options.delete('random')
+                    args + [options]
                   end)
 end

--- a/spec/lib/sidekiq_unique_jobs/unique_args_spec.rb
+++ b/spec/lib/sidekiq_unique_jobs/unique_args_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe SidekiqUniqueJobs::UniqueArgs do
   let(:item) { { 'class' => 'UntilExecutedJob', 'queue' => 'myqueue', 'args' => [[1, 2]] } }
   subject { described_class.new(item) }
 
-  context '#unique_digest' do
+  describe '#unique_digest' do
     let(:item) { item_options.merge('args' => [1, 2, 'type' => 'it'] ) }
 
-    shared_context 'unique digest' do
+    shared_examples 'unique digest' do
       context 'given another item' do
         let(:another_subject) { described_class.new(another_item) }
 
@@ -28,17 +28,22 @@ RSpec.describe SidekiqUniqueJobs::UniqueArgs do
     end
 
     context 'when unique_args is a proc' do
-      let(:item_options) { {'class' => 'UntilExecutedJob', 'queue' => 'myqueue',
-                            'unique_args' => Proc.new { |args| args[1] }} }
+      let(:item_options) do
+        { 'class' => 'UntilExecutedJob', 'queue' => 'myqueue',
+          'unique_args' => Proc.new { |args| args[1] } }
+      end
 
-      include_context 'unique digest'
+
+      it_behaves_like 'unique digest'
     end
 
     context 'when unique_args is a symbol' do
-      let(:item_options) { {'class' => 'UniqueJobWithFilterMethod', 'queue' => 'myqueue',
-                            'unique_args' => :filtered_args} }
+      let(:item_options) do
+        { 'class' => 'UniqueJobWithFilterMethod', 'queue' => 'myqueue',
+          'unique_args' => :filtered_args }
+      end
 
-      include_context 'unique digest'
+      it_behaves_like 'unique digest'
     end
   end
 


### PR DESCRIPTION
Hi!

There was a bug which made it so job's unique digest was calculated incorrectly when worker's unique_args option was specified. If unique_args was any thuthy value (e.g. a proc or a symbol), then at line 23 in file lib/sidekiq_unique_jobs/unique_args.rb nothing happened and unique_args calculation actually never took place.

I fixed this line and modified specs to test unique_digest generation for different cases of worker options.
Also I had to fix two existing test worker classes, because they were written with assumption that arguments are passed separately, but in fact in current implementation unique_args method or proc receive arguments as a single array, which by the way contradicts some examples in README file.

This PR should fix #138.