### PR TITLE
Remove wrong Server::Middleware#worker_class override

### DIFF
--- a/lib/sidekiq_unique_jobs/server/middleware.rb
+++ b/lib/sidekiq_unique_jobs/server/middleware.rb
@@ -18,7 +18,7 @@ module SidekiqUniqueJobs
 
       private
 
-      attr_reader :redis_pool, :worker, :item, :worker_class
+      attr_reader :redis_pool, :worker, :item
 
       protected
 


### PR DESCRIPTION
I want to run my job once per 10 mins and I created worker like this:
```ruby
class Workers::MyWorker
  include Sidekiq::Worker
  sidekiq_options unique: :until_timeout, unique_expiration: 10.minutes
end
```
But lock is removed after job completion. 

I found that instead of Lock::UntilTimeout the Lock::UntilExecuted is used. 

[This line in Server::Middleware](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/v4.0.13/lib/sidekiq_unique_jobs/server/middleware.rb#L21) overrides the worker_class delegator defined above:
```
class Middleware
  def_instance_delegator :@worker, :class, :worker_class
  ...
  attr_reader :redis_pool, :worker, :item, :worker_class
end
```

Because of this in [Server::Middleware#options](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/v4.0.13/lib/sidekiq_unique_jobs/options_with_fallback.rb#L50) `worker_class` is nil and `@options` is set to `Sidekiq.default_worker_options` insted of specified in my worker:
```ruby
def options
  @options ||= worker_class.get_sidekiq_options if worker_class.respond_to?(:get_sidekiq_options)
  @options ||= Sidekiq.default_worker_options
  @options ||= {}
  @options &&= @options.stringify_keys
end
```