### PR TITLE
Fix test overrides.

### DIFF
--- a/lib/sidekiq_unique_jobs/testing/sidekiq_overrides.rb
+++ b/lib/sidekiq_unique_jobs/testing/sidekiq_overrides.rb
@@ -3,8 +3,6 @@ require 'sidekiq/testing'
 module Sidekiq
   module Worker
     module ClassMethods
-      include SidekiqUniqueJobs::Unlockable
-
       # Drain and run all jobs for this worker
       def drain
         while (job = jobs.shift)
@@ -42,6 +40,10 @@ module Sidekiq
       def execute_job(worker, args)
         worker.perform(*args)
       end unless respond_to?(:execute_job)
+
+      def unlock(job)
+        SidekiqUniqueJobs::Unlockable.unlock(job)
+      end
     end
 
     module Overrides


### PR DESCRIPTION
Tests using this code failed with an undefined method error on the call to `unlock`. Since all we need from `Unlockable` is `unlock` it seems simpler and clearer to just explicitly alias the method.