### PR TITLE
Troubleshooting

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -46,16 +46,16 @@ module SidekiqUniqueJobs
                               argv: [item[JID_KEY], max_lock_time])
         case result
         when 3 # previously 1, was considered a success
-          logger.debug { "successfully locked #{unique_key} for #{max_lock_time} seconds (hsetnx called)" }
+          logger.debug { "?? successfully locked #{unique_key} for #{max_lock_time} seconds (hsetnx called)" }
           true
         when 2 # previously 0, was considered a failure
-          logger.debug { "failed to acquire lock for #{unique_key} (hsetnx not called)" }
+          logger.debug { "failed to acquire lock for #{unique_key} (hsetnx not called) -- #{item.inspect}" }
           false
         when 1
           logger.debug { "successfully locked #{unique_key} for #{max_lock_time} seconds (already set?)" }
           true
         when 0
-          logger.debug { "failed to acquire lock for #{unique_key} (stored_jid did not match job_id)" }
+          logger.debug { "failed to acquire lock for #{unique_key} (stored_jid did not match job_id) -- #{item.inspect}" }
           false
         else
           raise "#{__method__} returned an unexpected value (#{result})"

--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -45,11 +45,17 @@ module SidekiqUniqueJobs
                               keys: [unique_key],
                               argv: [item[JID_KEY], max_lock_time])
         case result
+        when 3 # previously 1, was considered a success
+          logger.debug { "successfully locked #{unique_key} for #{max_lock_time} seconds (hsetnx called)" }
+          true
+        when 2 # previously 0, was considered a failure
+          logger.debug { "failed to acquire lock for #{unique_key} (hsetnx not called)" }
+          false
         when 1
-          logger.debug { "successfully locked #{unique_key} for #{max_lock_time} seconds" }
+          logger.debug { "successfully locked #{unique_key} for #{max_lock_time} seconds (already set?)" }
           true
         when 0
-          logger.debug { "failed to acquire lock for #{unique_key}" }
+          logger.debug { "failed to acquire lock for #{unique_key} (stored_jid did not match job_id)" }
           false
         else
           raise "#{__method__} returned an unexpected value (#{result})"

--- a/lib/sidekiq_unique_jobs/unlockable.rb
+++ b/lib/sidekiq_unique_jobs/unlockable.rb
@@ -27,16 +27,27 @@ module SidekiqUniqueJobs
     def after_unlock(result, calling_method)
       case result
       when 1
-        logger.debug { "successfully unlocked #{unique_key}" }
+        logger.debug { "#{calling_method}: successfully unlocked #{unique_key} (del Ok, hdel Ok)" }
         true
+      when 2
+        logger.debug { "#{calling_method}: successfully unlocked #{unique_key} (del Ok, hdel failed)" }
+        true # previously considered a success
+      when 3
+        logger.debug { "#{calling_method}: successfully unlocked #{unique_key} (del failed, hdel Ok)" }
+        true # previously considered a success
+      when 4
+        logger.debug { "#{calling_method}: successfully unlocked #{unique_key} (del failed, hdel failed)" }
+        true # previously considered a success
       when 0
-        logger.debug { "expiring lock #{unique_key} is not owned by #{jid}" }
+        logger.debug { "#{calling_method}: expiring lock #{unique_key} is not owned by #{jid}" }
         false
       when -1
-        logger.debug { "#{unique_key} is not a known key" }
+        logger.debug { "#{calling_method}: #{unique_key} is not a known key" }
         false
       else
-        raise "#{calling_method} returned an unexpected value (#{result})"
+        msg = "#{calling_method}: returned an unexpected value (#{result})"
+        logger.debug { msg }
+        raise msg
       end
     end
 

--- a/redis/acquire_lock.lua
+++ b/redis/acquire_lock.lua
@@ -7,6 +7,7 @@ if stored_jid then
   if stored_jid == job_id then
     return 1
   else
+    -- maybe we should do something special in this case?
     return 0
   end
 end

--- a/redis/acquire_lock.lua
+++ b/redis/acquire_lock.lua
@@ -13,7 +13,7 @@ end
 
 if redis.pcall('set', unique_key, job_id, 'nx', 'ex', expires) then
   redis.pcall('hsetnx', 'uniquejobs', job_id, unique_key)
-  return 1
+  return 3
 else
-  return 0
+  return 2
 end

--- a/redis/release_lock.lua
+++ b/redis/release_lock.lua
@@ -4,9 +4,24 @@ local stored_jid = redis.pcall('get', unique_key)
 
 if stored_jid then
   if stored_jid == job_id or stored_jid == '2' then
-    redis.pcall('del', unique_key)
-    redis.pcall('hdel', 'uniquejobs', job_id)
-    return 1
+    if redis.pcall('del', unique_key) then
+      if redis.pcall('hdel', 'uniquejobs', job_id) then
+        -- All should be good
+        return 1
+      else
+        -- hdel has failed
+        return 2
+      end
+    else
+      -- del has failed, lets try hdel anyway.
+      if redis.pcall('hdel', 'uniquejobs', job_id) then
+        -- All should be good anyway ?
+        return 3
+      else
+        -- hdel has failed
+        return 4
+      end
+    end
   else
     return 0
   end

--- a/spec/lib/sidekiq_unique_jobs/scripts_spec.rb
+++ b/spec/lib/sidekiq_unique_jobs/scripts_spec.rb
@@ -33,19 +33,19 @@ RSpec.describe SidekiqUniqueJobs::Scripts do
 
     describe '.acquire_lock' do
       context 'when job is unique' do
-        specify { expect(lock_for).to eq(1) }
+        specify { expect(lock_for).to eq(3) }
         specify do
-          expect(lock_for(0.5)).to eq(1)
+          expect(lock_for(0.5)).to eq(3)
           expect(Redis)
             .to have_key(UNIQUE_KEY)
             .for_seconds(1)
             .with_value('fuckit')
           sleep 0.5
-          expect(lock_for).to eq(1)
+          expect(lock_for).to eq(3)
         end
 
         context 'when job is locked' do
-          before  { expect(lock_for(10)).to eq(1) }
+          before  { expect(lock_for(10)).to eq(3) }
           specify { expect(lock_for(5, 'anotherjid')).to eq(0) }
         end
       end
@@ -53,7 +53,7 @@ RSpec.describe SidekiqUniqueJobs::Scripts do
 
     describe '.release_lock' do
       context 'when job is locked by another jid' do
-        before  { expect(lock_for(10, 'anotherjid')).to eq(1) }
+        before  { expect(lock_for(10, 'anotherjid')).to eq(3) }
         specify { expect(unlock).to eq(0) }
         after { unlock(UNIQUE_KEY, ANOTHER_JID) }
       end
@@ -64,7 +64,7 @@ RSpec.describe SidekiqUniqueJobs::Scripts do
 
       context 'when job is locked by the same jid' do
         specify do
-          expect(lock_for(10)).to eq(1)
+          expect(lock_for(10)).to eq(3)
           expect(unlock).to eq(1)
         end
       end


### PR DESCRIPTION
I'm having issues with job failing to re-acquire the lock
they are defined like this.

```ruby
class LovelyWorker
  include Sidekiq::Worker
  sidekiq_options retry: false, backtrace: true, unique: :until_executing

  def perform(object_uuid)
    do_lovely_stuff
    LovelyWorker.perform_in(15.seconds, object_uuid)
  end
end
```

I've split the return codes of the lua scripts, and added some debugging to understand a bit better what is going on... I was wondering if this added information could be useful to others, so I am opening a pull request.

The error looks like this

```
sidekiq.log:444461:2016-03-18T00:17:55.525Z 20899 TID-10xnnk SeasonMaintainerWorker JID-515066574f2af0660cc440bb DEBUG: failed to acquire lock for uniquejobs:17042957acafcc6506ef21a15f371999 (stored_jid did not match job_id) -- {"class"=>"PreGameWorker", "args"=>["2b9028c3-c482-4300-89fe-64e133aad607"], "at"=>1458261900.0, "retry"=>false, "queue"=>"default", "backtrace"=>true, "unique"=>:until_executing, "jid"=>"f0e5d10cffbb6a1d56e03cdd", "created_at"=>1458260275.5235777, "unique_prefix"=>"uniquejobs", "unique_args"=>["2b9028c3-c482-4300-89fe-64e133aad607"], "unique_digest"=>"uniquejobs:17042957acafcc6506ef21a15f371999"}
```

What I am noticing from this log line..
the class name of the job trying to get the lock is not the same one as the one who apparently owns the lock.

and these workers don't even have similar arguments, so it should have never match...

I'm not too sure what is going on, any help will be appreciated

thanks

