### PR TITLE
Fixed gitter badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,7 @@ Start the console with the following command `bundle exec jobs console`.
 
 ## Communication
 
-There is a [![Join the chat at https://gitter.im/mhenrixon/sidekiq-unique-jobs](https://badges.gitter.im/mhenrixon/sidekiq-unique-jobs.svg)](https://gitter.im/mhenri
-xon/sidekiq-unique-jobs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) for praise or scorn. This would be a good place to have lengthy discuss or brilliant suggestions or simply just nudge me if I forget about anything.
+There is a [![Join the chat at https://gitter.im/mhenrixon/sidekiq-unique-jobs](https://badges.gitter.im/mhenrixon/sidekiq-unique-jobs.svg)](https://gitter.im/mhenrixon/sidekiq-unique-jobs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) for praise or scorn. This would be a good place to have lengthy discuss or brilliant suggestions or simply just nudge me if I forget about anything.
 
 ## Testing
 


### PR DESCRIPTION
Removed linebreak that markdown was encoding into the url.

Thanks for the gem, I'm using it on https://libraries.io to great effect! 👌