### PR TITLE
fix for #168. Handle the NOSCRIPT by sending the script again

### DIFF
--- a/lib/sidekiq_unique_jobs/scripts.rb
+++ b/lib/sidekiq_unique_jobs/scripts.rb
@@ -33,10 +33,8 @@ module SidekiqUniqueJobs
         call(file_name, redis_pool, options)
       else
         raise ScriptError,
-              "#{file_name}.lua\n\n" +
-              ex.message + "\n\n" +
-              script_source(file_name) +
-              ex.backtrace.join("\n")
+              "#{file_name}.lua\n\n#{ex.message}\n\n#{script_source(file_name)}" \
+              "#{ex.backtrace.join("\n")}"
       end
     end
 

--- a/lib/sidekiq_unique_jobs/scripts.rb
+++ b/lib/sidekiq_unique_jobs/scripts.rb
@@ -28,11 +28,16 @@ module SidekiqUniqueJobs
         redis.evalsha(script_shas[file_name], options)
       end
     rescue Redis::CommandError => ex
-      raise ScriptError,
-            "#{file_name}.lua\n\n" +
-            ex.message + "\n\n" +
-            script_source(file_name) +
-            ex.backtrace.join("\n")
+      if ex.message == 'NOSCRIPT No matching script. Please use EVAL.'
+        script_shas[file_name] = nil
+        call(file_name, redis_pool, options)
+      else
+        raise ScriptError,
+              "#{file_name}.lua\n\n" +
+              ex.message + "\n\n" +
+              script_source(file_name) +
+              ex.backtrace.join("\n")
+      end
     end
 
     def script_source(file_name)


### PR DESCRIPTION
Run EVAL again if NOSCRIPT error happens. This will fix #168 
Based on the documentation from http://redis.io/commands/EVAL#bandwidth-and-evalsha:
` The client library implementation can always optimistically send EVALSHA under the hood even when the client actually calls EVAL, in the hope the script was already seen by the server. If the NOSCRIPT error is returned EVAL will be used instead. `