### PR TITLE
unique args need to be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Requiring the gem in your gemfile should be sufficient to enable unique jobs.
 ```ruby
 Sidekiq.default_worker_options = {
   unique: :until_executing,
-  unique_args: ->(args) { args.first.except('job_id') }
+  unique_args: ->(args) { [ args.first.except('job_id') ] }
 }
 ```
 


### PR DESCRIPTION
I think the documentation led me astray.  Followed this example for ActiveJob, but that returns a hash, not an array, and my job uniqueness was not enforced.