### PR TITLE
Increase sleep delay in WhileExecuting#synchronize

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/while_executing.rb
@@ -14,7 +14,7 @@ module SidekiqUniqueJobs
 
       def synchronize
         @mutex.lock
-        sleep 0.001 until locked?
+        sleep 0.1 until locked?
 
         yield
       rescue Sidekiq::Shutdown


### PR DESCRIPTION
Sleeping for 100ms instead of 1ms reduces the load both on the sidekiq process as well as redis. Before a few jobs trying to acquire the lock slowed down running jobs significantly by spending almost all of the available cpu time checking for the lock.