### PR TITLE
Ensure job ID removed from uniquejobs hash

### DIFF
--- a/lib/sidekiq_unique_jobs/unlockable.rb
+++ b/lib/sidekiq_unique_jobs/unlockable.rb
@@ -25,6 +25,8 @@ module SidekiqUniqueJobs
     end
 
     def after_unlock(result, calling_method)
+      ensure_job_id_removed
+
       case result
       when 1
         logger.debug { "successfully unlocked #{unique_key}" }
@@ -38,6 +40,10 @@ module SidekiqUniqueJobs
       else
         raise "#{calling_method} returned an unexpected value (#{result})"
       end
+    end
+
+    def ensure_job_id_removed
+      Sidekiq.redis { |redis| redis.hdel("uniquejobs", jid) }
     end
 
     def logger


### PR DESCRIPTION
Adds changes from https://github.com/mhenrixon/sidekiq-unique-jobs/pull/200
on top of release version 4.0.18. This way we can safely test these
additions to the gem without having to bring in other breaking changes
in master.