### PR TITLE
Add activesupport as a dependency

### DIFF
--- a/lib/sidekiq-unique-jobs.rb
+++ b/lib/sidekiq-unique-jobs.rb
@@ -18,6 +18,7 @@ require 'sidekiq_unique_jobs/config'
 require 'sidekiq_unique_jobs/sidekiq_unique_ext'
 
 require 'ostruct'
+require 'active_support/core_ext/string/inflections'
 
 module SidekiqUniqueJobs
   module_function

--- a/lib/sidekiq_unique_jobs/options_with_fallback.rb
+++ b/lib/sidekiq_unique_jobs/options_with_fallback.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'active_support/core_ext/class/attribute'
 
 module SidekiqUniqueJobs
   module OptionsWithFallback

--- a/lib/sidekiq_unique_jobs/version.rb
+++ b/lib/sidekiq_unique_jobs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqUniqueJobs
-  VERSION = '5.0.8'
+  VERSION = '5.0.9'
 end

--- a/sidekiq-unique-jobs.gemspec
+++ b/sidekiq-unique-jobs.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.add_dependency 'sidekiq', '>= 4.0', '<= 6.0'
   spec.add_dependency 'thor', '~> 0'
+  spec.add_dependency 'activesupport'
 
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
There are non standard ruby methods called like:
- String#constantize
- Class#class_attribute

When using this gem in non rails apps, we get a no method error for
these methods.

In this change, we add activesupport as a dependency and require the
following modules which contains the missing methods:

```ruby
require 'active_support/core_ext/class/attribute'
require 'active_support/core_ext/string/inflections'
```