### PR TITLE
Fixed documentation example about unique_args

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ class UniqueJobWithFilterMethod
   sidekiq_options unique: :until_and_while_executing,
                   unique_args: :unique_args
 
-  def self.unique_args(name, id, options)
-    [ name, options[:type] ]
+  def self.unique_args(args)
+    [ args[0], args[2][:type] ]
   end
 
   ...


### PR DESCRIPTION
When defining `unique_args` with symbol the arguments are passed to the method as Array.

Tested locally and checked this [class](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/d645647bcb15903801e65e2335661deca97d4319/spec/jobs/custom_queue_job_with_filter_method.rb).