### PR TITLE
Use hscan for Util#expire

### DIFF
--- a/lib/sidekiq_unique_jobs/util.rb
+++ b/lib/sidekiq_unique_jobs/util.rb
@@ -6,6 +6,7 @@ module SidekiqUniqueJobs
     DEFAULT_COUNT ||= 1_000
     KEYS_METHOD ||= 'keys'
     SCAN_METHOD ||= 'scan'
+    EXPIRE_BATCH_SIZE ||= 100
 
     module_function
 
@@ -44,8 +45,7 @@ module SidekiqUniqueJobs
       removed_keys = {}
       connection do |conn|
         cursor = '0'
-        batch_size = 100
-        cursor, jobs = conn.hscan(SidekiqUniqueJobs::HASH_KEY, [cursor, 'MATCH', '*', 'COUNT', batch_size])
+        cursor, jobs = conn.hscan(SidekiqUniqueJobs::HASH_KEY, [cursor, 'MATCH', '*', 'COUNT', EXPIRE_BATCH_SIZE])
         jobs.each do |job_array|
           jid, unique_key = job_array
           next if conn.get(unique_key)

--- a/lib/sidekiq_unique_jobs/util.rb
+++ b/lib/sidekiq_unique_jobs/util.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'pry'
 
 module SidekiqUniqueJobs
   module Util


### PR DESCRIPTION
For large apps, `hgetall` can take forever which will block Redis and suspend any Sidekiq job execution. Use `hscan` instead. 

A question: is it useful to report the `removed_keys`? The issue is that with a huge app collecting all the IDs this will end up cloning `uniquekeys` in RAM on the app server. One of our production apps has a multi-gigabyte `uniquekeys` hash and running `expire` will kill it. If this is useful, I could add something like `Util#silently_expire` with a matching Rake task. 