### PR TITLE
Your testing lib is broken and don't permit to test uniqueness of jobs

### DIFF
--- a/lib/sidekiq_unique_jobs/client/middleware.rb
+++ b/lib/sidekiq_unique_jobs/client/middleware.rb
@@ -10,6 +10,7 @@ module SidekiqUniqueJobs
       include OptionsWithFallback
 
       def call(worker_class, item, queue, redis_pool = nil)
+        puts "* Client processing: #{worker_class}"
         @worker_class = worker_class_constantize(worker_class)
         @item = item
         @queue = queue

--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -41,9 +41,11 @@ module SidekiqUniqueJobs
           raise ArgumentError, "#{scope} middleware can't #{__method__} #{unique_key}"
         end
 
+        puts "lock for #{unique_key}"
         result = Scripts.call(:acquire_lock, redis_pool,
                               keys: [unique_key],
                               argv: [item[JID_KEY], max_lock_time])
+        puts "<- lock for #{unique_key}"
         case result
         when 1
           logger.debug { "successfully locked #{unique_key} for #{max_lock_time} seconds" }

--- a/lib/sidekiq_unique_jobs/server/middleware.rb
+++ b/lib/sidekiq_unique_jobs/server/middleware.rb
@@ -8,6 +8,7 @@ module SidekiqUniqueJobs
       include OptionsWithFallback
 
       def call(worker, item, queue, redis_pool = nil, &blk)
+        puts "* Server processing: #{worker.class}"
         @worker = worker
         @redis_pool = redis_pool
         @queue = queue

--- a/lib/sidekiq_unique_jobs/testing.rb
+++ b/lib/sidekiq_unique_jobs/testing.rb
@@ -44,8 +44,8 @@ module SidekiqUniqueJobs
         worker_class = SidekiqUniqueJobs.worker_class_constantize(worker_class)
 
         if Sidekiq::Testing.inline?
-          _server.call(worker_class.new, item, queue, redis_pool) do
-            call_real(worker_class, item, queue, redis_pool) do
+          call_real(worker_class, item, queue, redis_pool) do
+            _server.call(worker_class.new, item, queue, redis_pool) do
               yield
             end
           end

--- a/lib/sidekiq_unique_jobs/unlockable.rb
+++ b/lib/sidekiq_unique_jobs/unlockable.rb
@@ -7,21 +7,27 @@ module SidekiqUniqueJobs
     end
 
     def unlock_by_key(unique_key, jid, redis_pool = nil)
+      puts ">= release lock for #{unique_key}"
       Scripts.call(:release_lock, redis_pool, keys: [unique_key], argv: [jid]) do |result|
         after_unlock(result, __method__)
       end
+      puts "<- release lock for #{unique_key}"
     end
 
     def unlock_by_jid(jid, redis_pool = nil)
+      puts ">= release lock for #{jid}"
       Scripts.call(:release_lock_by_jid, redis_pool, keys: [jid]) do |result|
         after_unlock(result, __method__)
       end
+      puts "<- release lock for #{jid}"
     end
 
     def unlock_by_arguments(_worker_class, _unique_arguments = {})
+      puts ">= release lock for #{_worker_class} #{_unique_arguments}"
       Scripts.call(:release_lock, redis_pool, keys: [unique_key], argv: [jid]) do |result|
         after_unlock(result, __method__)
       end
+      puts "<- release lock for #{_worker_class} #{_unique_arguments}"
     end
 
     def after_unlock(result, calling_method)


### PR DESCRIPTION
Hello,

I discovered an issue when migrating from 3.0.11 to 4.0.18.

Inside this file: 
>lib/sidekiq_unique_jobs/testing.rb

You decided to do that:
```ruby
          _server.call(worker_class.new, item, queue, redis_pool) do
            call_real(worker_class, item, queue, redis_pool) do
               yield
             end
           end
```

Instead of that (my solution):
```ruby
          call_real(worker_class, item, queue, redis_pool) do
            _server.call(worker_class.new, item, queue, redis_pool) do
              yield
            end
          end
```

It does not make sense because it means in your version you run the server first (the server is the one who performs the job), then you run the client (client pushs the jobs)

It means in details, at first you release the lock then in the client you acquire a lock, but NO, at first you should acquire a lock... and then  after processing the job the lock should be released by the server?! So basically when you want to execute complicated specs where the uniqueness is important we faced of an issue because the lock just don't work. I wasted many days to understand why.

I left some puts in the PR to help you to understand the issue :). But this should of course be removed. 

Otherwise good job for the 4.0.18 it's much better than 3.0.11 :+1: 