### PR TITLE
Your testing lib is broken and don't permit to test uniqueness of jobs

### DIFF
--- a/lib/sidekiq_unique_jobs/client/middleware.rb
+++ b/lib/sidekiq_unique_jobs/client/middleware.rb
@@ -12,6 +12,7 @@ module SidekiqUniqueJobs
       include OptionsWithFallback
 
       def call(worker_class, item, queue, redis_pool = nil)
+        puts "* Client processing: #{worker_class}"
         @worker_class = worker_class_constantize(worker_class)
         @item = item
         @queue = queue

--- a/lib/sidekiq_unique_jobs/script_mock.rb
+++ b/lib/sidekiq_unique_jobs/script_mock.rb
@@ -24,7 +24,9 @@ module SidekiqUniqueJobs
         return (stored_jid == job_id) ? 1 : 0 if stored_jid
 
         return 0 unless conn.set(unique_key, job_id, nx: true, ex: expires)
+        puts "+. acquire_lock start with #{options}"
         conn.hsetnx(SidekiqUniqueJobs::HASH_KEY, job_id, unique_key)
+        puts "=. acquire_lock done #{options}"
         return 1
       end
     end
@@ -38,8 +40,10 @@ module SidekiqUniqueJobs
         return -1 unless stored_jid
         return 0 unless stored_jid == job_id || stored_jid == '2'
 
+        puts "-. release_lock start with #{options}"
         conn.del(unique_key)
         conn.hdel(SidekiqUniqueJobs::HASH_KEY, job_id)
+        puts "=. release_lock done #{options}"
         return 1
       end
     end

--- a/lib/sidekiq_unique_jobs/server/middleware.rb
+++ b/lib/sidekiq_unique_jobs/server/middleware.rb
@@ -10,6 +10,7 @@ module SidekiqUniqueJobs
       include OptionsWithFallback
 
       def call(worker, item, queue, redis_pool = nil, &blk)
+        puts "* Server processing: #{worker.class}"
         @worker = worker
         @redis_pool = redis_pool
         @queue = queue

--- a/lib/sidekiq_unique_jobs/testing.rb
+++ b/lib/sidekiq_unique_jobs/testing.rb
@@ -46,8 +46,8 @@ module SidekiqUniqueJobs
         worker_class = SidekiqUniqueJobs.worker_class_constantize(worker_class)
 
         if Sidekiq::Testing.inline?
-          _server.call(worker_class.new, item, queue, redis_pool) do
-            call_real(worker_class, item, queue, redis_pool) do
+          call_real(worker_class, item, queue, redis_pool) do
+            _server.call(worker_class.new, item, queue, redis_pool) do
               yield
             end
           end


### PR DESCRIPTION
Hello,

I discovered an issue when migrating from 3.0.11 to 4.0.18.

Inside this file: 
>lib/sidekiq_unique_jobs/testing.rb

You decided to do that:
```ruby
          _server.call(worker_class.new, item, queue, redis_pool) do
            call_real(worker_class, item, queue, redis_pool) do
               yield
             end
           end
```

Instead of that (my solution):
```ruby
          call_real(worker_class, item, queue, redis_pool) do
            _server.call(worker_class.new, item, queue, redis_pool) do
              yield
            end
          end
```

It does not make sense because it means in your version you run the server first (the server is the one who performs the job), then you run the client (client pushs the jobs)

It means in details, at first you release the lock then in the client you acquire a lock, but NO, at first you should acquire a lock... and then  after processing the job the lock should be released by the server?! So basically when you want to execute complicated specs where the uniqueness is important we faced of an issue because the lock just don't work. I wasted many days to understand why.

I left some puts in the PR to help you to understand the issue :). But this should of course be removed. 

Otherwise good job for the 4.0.18 it's much better than 3.0.11 :+1: 

**Edit:** sorry for the previous PR (https://github.com/mhenrixon/sidekiq-unique-jobs/pull/231) I was unable to provide you a valid PR without comparing with master and my previous PR was relying on a tag version, so I recreated a new one.