### PR TITLE
Don't skip monkeypatches if ActiveSupport present

### DIFF
--- a/lib/sidekiq_unique_jobs/core_ext.rb
+++ b/lib/sidekiq_unique_jobs/core_ext.rb
@@ -1,43 +1,38 @@
 # frozen_string_literal: true
 
-begin
-  require 'active_support/core_ext/hash/keys'
-  require 'active_support/core_ext/hash/deep_merge'
-rescue LoadError
-  class Hash
-    unless {}.respond_to?(:slice)
-      def slice(*keys)
-        keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
-        keys.each_with_object(self.class.new) { |k, hash| hash[k] = self[k] if key?(k) }
-      end
+class Hash
+  unless {}.respond_to?(:slice)
+    def slice(*keys)
+      keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
+      keys.each_with_object(self.class.new) { |k, hash| hash[k] = self[k] if key?(k) }
     end
+  end
 
-    unless {}.respond_to?(:stringify_keys)
-      def stringify_keys
-        transform_keys(&:to_s)
-      end
+  unless {}.respond_to?(:stringify_keys)
+    def stringify_keys
+      transform_keys(&:to_s)
     end
+  end
 
-    unless {}.respond_to?(:transform_keys)
-      def transform_keys
-        result = {}
-        each_key do |key|
-          result[yield(key)] = self[key]
-        end
-        result
+  unless {}.respond_to?(:transform_keys)
+    def transform_keys
+      result = {}
+      each_key do |key|
+        result[yield(key)] = self[key]
       end
+      result
     end
+  end
 
-    unless {}.respond_to?(:slice!)
-      def slice!(*keys)
-        keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
-        omit = slice(*self.keys - keys)
-        hash = slice(*keys)
-        hash.default      = default
-        hash.default_proc = default_proc if default_proc
-        replace(hash)
-        omit
-      end
+  unless {}.respond_to?(:slice!)
+    def slice!(*keys)
+      keys.map! { |key| convert_key(key) } if respond_to?(:convert_key, true)
+      omit = slice(*self.keys - keys)
+      hash = slice(*keys)
+      hash.default      = default
+      hash.default_proc = default_proc if default_proc
+      replace(hash)
+      omit
     end
   end
 end


### PR DESCRIPTION
_TLDR: removes two superfluous-seeming checks in core_ext that cause breakage if ActiveSupport is in the require path but not fully loaded._

sidekiq-unique-jobs needs a small number of methods from ActiveSupport. It vendors these methods in case ActiveSupport isn't present.

Currently those methods are only added if ActiveSupport is _nowhere Ruby's require path_. This breaks in the following cases:
- ActiveSupport is being used the application but only a subset of methods are included.
- ActiveSupport is present in the load path but is not being used as part of the application.

This removes the check on whether ActiveSupport is loadable. The solves the above two cases , while still not avoiding re-adding methods in the case that ActiveSupport has already added them.