### PR TITLE
Allow `jobs keys` to default to listing all keys

### DIFF
--- a/lib/sidekiq_unique_jobs/cli.rb
+++ b/lib/sidekiq_unique_jobs/cli.rb
@@ -14,7 +14,7 @@ module SidekiqUniqueJobs
 
     desc 'keys PATTERN', 'list all unique keys and their expiry time'
     option :count, aliases: :c, type: :numeric, default: 1000, desc: 'The max number of keys to return'
-    def keys(pattern)
+    def keys(pattern = '*')
       keys = Util.keys(pattern, options[:count])
       say "Found #{keys.size} keys matching '#{pattern}':"
       print_in_columns(keys.sort) if keys.any?


### PR DESCRIPTION
I was having an issue on my Windows installation where I couldn't list any jobs through the command line.

This commit allows the "keys" command to take a default of "*", which helps Windows installations, where the Windows CLI interacts poorly with `bundle exec jobs keys '*'`:

```
ERROR: "jobs keys" was called with arguments [ (every file in the working directory ) ]
```

It's still possible to run `bundle exec jobs keys <pattern>` as necessary.