### PR TITLE
Remove unnecessary monkey patches for String

### DIFF
--- a/lib/sidekiq_unique_jobs/core_ext.rb
+++ b/lib/sidekiq_unique_jobs/core_ext.rb
@@ -48,27 +48,3 @@ class Array
     end
   end
 end
-
-class String
-  unless ''.respond_to?(:classify)
-    def classify
-      camelize(sub(/.*\./, ''))
-    end
-  end
-
-  unless ''.respond_to?(:camelize)
-    def camelize(uppercase_first_letter = true)
-      string = self
-      string = if uppercase_first_letter
-                 string.sub(/^[a-z\d]*/) { $&.capitalize }
-               else
-                 string.sub(/^(?:(?=\b|[A-Z_])|\w)/) { $&.downcase }
-               end
-      string.gsub!(%r{(?:_|(\/))([a-z\d]*)}i) do
-        "#{Regexp.last_match(1)}#{Regexp.last_match(2).capitalize}"
-      end
-      string.gsub!(%r{/}, '::')
-      string
-    end
-  end
-end

--- a/spec/unit/core_ext_spec.rb
+++ b/spec/unit/core_ext_spec.rb
@@ -13,15 +13,3 @@ RSpec.describe Hash do
     specify { expect { subject.slice!(:test) }.to change { subject }.to(test: :me) }
   end
 end
-
-RSpec.describe String do
-  describe '#classify' do
-    subject { 'under_scored_string' }
-    its(:classify) { is_expected.to eq('UnderScoredString') }
-  end
-
-  describe '#camelize' do
-    subject { 'under_scored_string' }
-    its(:camelize) { is_expected.to eq('UnderScoredString') }
-  end
-end


### PR DESCRIPTION
The current stable version of the gem monkey patches a couple of core classes, including String. Unfortunately, the definition of the `camelize` method conflicts with other gems' definition of this same method including Active Support and Backports (see [https://github.com/marcandre/backports/blob/v3.11.3/lib/backports/rails/string.rb](url)). I actually noticed the behavior by requiring backports before sidekiq-unique-jobs and getting a failure of `Wrong constant name 'untilExecuted'`.

The locking mechanism has already been cleaned up in the master branch (although it hasn't been released yet) but the - now unused - monkey patches for String have been left over. I think removing these can spare developers hunting down subtle bugs.