### PR TITLE
Add explicit concurrent-ruby dependency.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,6 +11,7 @@ engines:
         - ruby
   rubocop:
     enabled: true
+    channel: rubocop-0-54
 ratings:
   paths:
     - lib/**

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,11 +35,23 @@ Metrics/BlockLength:
 Metrics/PerceivedComplexity:
   Max: 8
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: true
 
-Style/ConstantName:
+Naming/ConstantName:
   Enabled: true
+
+Naming/FileName:
+  Enabled: true
+  Exclude:
+    - 'lib/sidekiq-unique-jobs.rb'
+    - '**/Gemfile'
+    - '**/Appraisals'
+    - '**/*.gemspec'
+
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+    - ex
 
 Style/FrozenStringLiteralComment:
   Enabled: true
@@ -50,14 +62,6 @@ Style/Documentation:
 Style/SignalException:
   EnforcedStyle: only_fail
   Enabled: false
-
-Style/FileName:
-  Enabled: true
-  Exclude:
-    - 'lib/sidekiq-unique-jobs.rb'
-    - '**/Gemfile'
-    - '**/Appraisals'
-    - '**/*.gemspec'
 
 Style/GlobalVars:
   Enabled: true
@@ -84,6 +88,10 @@ Style/TrailingCommaInArguments:
   Enabled: true
   EnforcedStyleForMultiline: comma
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: comma

--- a/sidekiq-unique-jobs.gemspec
+++ b/sidekiq-unique-jobs.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.require_paths = ['lib']
+  spec.add_dependency 'concurrent-ruby', '~> 1.0', '>= 1.0.5'
   spec.add_dependency 'sidekiq', '>= 4.0', '<= 6.0'
   spec.add_dependency 'thor', '~> 0'
 


### PR DESCRIPTION
The latest master of sidekiq no longer uses the concurrent-ruby dependency.

Current master is failing the `sidekiq_develop` tests as a result.