### PR TITLE
Fix inverted logic in WhileExecuting lock.

### DIFF
--- a/spec/support/sidekiq_meta.rb
+++ b/spec/support/sidekiq_meta.rb
@@ -3,15 +3,14 @@
 RSpec.configure do |config| # rubocop:disable Metrics/BlockLength
   config.before(:each, redis: :mock_redis) do
     require 'mock_redis'
-    mock_redis = MockRedis.new
+    @redis = MockRedis.new
     SidekiqUniqueJobs.configure do |unique|
       unique.redis_test_mode = :mock
     end
     allow(SidekiqUniqueJobs).to receive(:mocked?).and_return(true)
     allow(SidekiqUniqueJobs).to receive(:redis_version).and_return('0.0')
-    Sidekiq::Worker.clear_all
 
-    allow(Sidekiq).to receive(:redis).and_yield(mock_redis)
+    allow(Sidekiq).to receive(:redis).and_yield(@redis)
   end
 
   config.before(:each, redis: :redis) do |example|

--- a/spec/unit/lock/while_executing_spec.rb
+++ b/spec/unit/lock/while_executing_spec.rb
@@ -2,5 +2,63 @@
 
 require 'spec_helper'
 
-RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting, redis: :redis do
+RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting, redis: :mock_redis do
+  let(:lock) { described_class.new(item) }
+
+  let(:item) do
+    {
+      'jid' => 'job-id',
+      'class' => 'WhileExecutingJob',
+      'unique' => 'while_executing'
+    }
+  end
+
+  describe '#lock' do
+    it { expect(lock.lock(:client)).to eq(true) }
+  end
+
+  describe '#execute' do
+    it 'locks' do
+      expect(@redis.keys.length).to eq(0)
+
+      callback = spy
+      lock.execute(callback) do
+        expect(@redis.keys.length).to eq(2)
+        expect(callback).not_to have_received(:call)
+      end
+
+      expect(@redis.keys.length).to eq(0)
+      expect(callback).to have_received(:call)
+    end
+
+    it 'releases the lock even if the block raises' do
+      expect do
+        lock.execute(-> {}) do
+          raise StandardError, 'fake error'
+        end
+      end.to raise_error(StandardError)
+
+      expect(@redis.keys.length).to eq(0)
+    end
+
+    it 'does not raise an with a zero timeout if it cannot acquire' do
+      duplicate_lock = described_class.new(item.merge(SidekiqUniqueJobs::LOCK_TIMEOUT_KEY => 0))
+      block = -> {}
+
+      lock.execute(-> {}) do
+        expect(block).not_to receive(:call)
+        expect { duplicate_lock.execute(-> {}, &block) }.not_to raise_error
+      end
+    end
+
+    it 'raises with a non-zero timeout if it cannot acquire' do
+      duplicate_lock = described_class.new(item.merge(SidekiqUniqueJobs::LOCK_TIMEOUT_KEY => 5))
+      block = -> {}
+
+      lock.execute(-> {}) do
+        expect(block).not_to receive(:call)
+        expect { duplicate_lock.execute(-> {}, &block) }.to raise_error(SidekiqUniqueJobs::LockTimeout)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, the lock was being unlocked immediately before the job was yielded to.

@mhenrixon I know it's been a while since you did your refactor here on how locks work -- but please let me know if I'm missing something here -- it looks like the current master unlocks the job immediately after acquiring the lock for the `WhileExecuting` lock.