### PR TITLE
Rename UntilTimeout -> UntilExpired

### DIFF
--- a/.reek
+++ b/.reek
@@ -31,7 +31,7 @@ IrresponsibleModule:
   - SidekiqUniqueJobs::Lock::UntilAndWhileExecuting
   - SidekiqUniqueJobs::Lock::UntilExecuted
   - SidekiqUniqueJobs::Lock::UntilExecuting
-  - SidekiqUniqueJobs::Lock::UntilTimeout
+  - SidekiqUniqueJobs::Lock::UntilExpired
   - SidekiqUniqueJobs::Lock::WhileExecuting
   - SidekiqUniqueJobs::Lock::WhileExecutingReject
   - SidekiqUniqueJobs::Lock::WhileExecutingRequeue

--- a/examples/custom_queue_job_with_filter_proc.rb
+++ b/examples/custom_queue_job_with_filter_proc.rb
@@ -7,7 +7,7 @@ require_relative './custom_queue_job'
 class CustomQueueJobWithFilterProc < CustomQueueJob
   # slightly contrived example of munging args to the
   # worker and removing a random bit.
-  sidekiq_options unique: :until_timeout,
+  sidekiq_options unique: :until_expired,
                   unique_args: (lambda do |args|
                     options = args.extract_options!
                     options.delete('random')

--- a/examples/until_expired_job.rb
+++ b/examples/until_expired_job.rb
@@ -2,9 +2,9 @@
 
 # :nocov:
 
-class UntilTimeoutJob
+class UntilExpiredJob
   include Sidekiq::Worker
-  sidekiq_options unique: :until_timeout, lock_expiration: 10 * 60, lock_timeout: 10
+  sidekiq_options unique: :until_expired, lock_expiration: 10 * 60
 
   def perform(one)
     TestClass.run(one)

--- a/examples/until_global_expired_job.rb
+++ b/examples/until_global_expired_job.rb
@@ -2,9 +2,9 @@
 
 # :nocov:
 
-class UntilGlobalTimeoutJob
+class UntilGlobalExpiredJob
   include Sidekiq::Worker
-  sidekiq_options unique: :until_timeout
+  sidekiq_options unique: :until_expired
 
   def perform(arg)
     TestClass.run(arg)

--- a/lib/sidekiq_unique_jobs/lock/until_expired.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_expired.rb
@@ -2,7 +2,7 @@
 
 module SidekiqUniqueJobs
   class Lock
-    class UntilTimeout < BaseLock
+    class UntilExpired < BaseLock
       def unlock
         true
       end

--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -226,7 +226,7 @@ end
 require 'sidekiq_unique_jobs/lock/base_lock'
 require 'sidekiq_unique_jobs/lock/until_executed'
 require 'sidekiq_unique_jobs/lock/until_executing'
-require 'sidekiq_unique_jobs/lock/until_timeout'
+require 'sidekiq_unique_jobs/lock/until_expired'
 require 'sidekiq_unique_jobs/lock/while_executing'
 require 'sidekiq_unique_jobs/lock/while_executing_reject'
 require 'sidekiq_unique_jobs/lock/while_executing_requeue'

--- a/lib/sidekiq_unique_jobs/options_with_fallback.rb
+++ b/lib/sidekiq_unique_jobs/options_with_fallback.rb
@@ -11,7 +11,7 @@ module SidekiqUniqueJobs
       until_and_while_executing: SidekiqUniqueJobs::Lock::UntilAndWhileExecuting,
       until_executed:            SidekiqUniqueJobs::Lock::UntilExecuted,
       until_executing:           SidekiqUniqueJobs::Lock::UntilExecuting,
-      until_timeout:             SidekiqUniqueJobs::Lock::UntilTimeout,
+      until_expired:             SidekiqUniqueJobs::Lock::UntilExpired,
       while_executing:           SidekiqUniqueJobs::Lock::WhileExecuting,
       while_executing_reject:    SidekiqUniqueJobs::Lock::WhileExecutingReject,
     }.freeze

--- a/spec/examples/custom_queue_job_with_filter_proc_spec.rb
+++ b/spec/examples/custom_queue_job_with_filter_proc_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CustomQueueJobWithFilterProc do
       {
         'queue'       => :customqueue,
         'retry'       => true,
-        'unique'      => :until_timeout,
+        'unique'      => :until_expired,
         'unique_args' => a_kind_of(Proc),
       }
     end

--- a/spec/examples/until_expired_job_spec.rb
+++ b/spec/examples/until_expired_job_spec.rb
@@ -2,14 +2,13 @@
 
 require 'spec_helper'
 
-RSpec.describe UntilTimeoutJob do
+RSpec.describe UntilExpiredJob do
   it_behaves_like 'sidekiq with options' do
     let(:options) do
       {
         'lock_expiration' => 600,
-        'lock_timeout'    => 10,
         'retry'           => true,
-        'unique'          => :until_timeout,
+        'unique'          => :until_expired,
       }
     end
   end

--- a/spec/examples/until_global_expired_job_spec.rb
+++ b/spec/examples/until_global_expired_job_spec.rb
@@ -2,12 +2,12 @@
 
 require 'spec_helper'
 
-RSpec.describe UntilGlobalTimeoutJob do
+RSpec.describe UntilGlobalExpiredJob do
   it_behaves_like 'sidekiq with options' do
     let(:options) do
       {
         'retry'  => true,
-        'unique' => :until_timeout,
+        'unique' => :until_expired,
       }
     end
   end

--- a/spec/unit/sidekiq_unique_jobs/lock/until_executing_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/lock/until_executing_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilExecuting do
 
   let(:item) do
     { 'jid' => 'maaaahjid',
-      'class' => 'UntilTimeoutJob',
+      'class' => 'UntilExpiredJob',
       'unique' => 'until_timeout' }
   end
   let(:empty_callback) { -> {} }

--- a/spec/unit/sidekiq_unique_jobs/lock/until_expired_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/lock/until_expired_spec.rb
@@ -2,12 +2,12 @@
 
 require 'spec_helper'
 
-RSpec.describe SidekiqUniqueJobs::Lock::UntilTimeout do
+RSpec.describe SidekiqUniqueJobs::Lock::UntilExpired do
   include_context 'with a stubbed locksmith'
 
   let(:item) do
     { 'jid' => 'maaaahjid',
-      'class' => 'UntilTimeoutJob',
+      'class' => 'UntilExpiredJob',
       'unique' => 'until_timeout' }
   end
   let(:empty_callback) { -> {} }


### PR DESCRIPTION
The timeout part of the lock suggested it be used with the configuration option
`lock_timeout: ` which was misleading. It is intended to be used with:
`lock_expiration:`.