### PR TITLE
Fix UntilExpired

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -11,7 +11,8 @@ SimpleCov.start do
   add_filter '/spec/'
   add_filter '/bin/'
   add_filter '/gemfiles/'
-  add_group 'Workers', 'examples/'
+  add_filter '/examples/'
+
   add_group 'Client', 'lib/sidekiq_unique_jobs/client'
   add_group 'Locks', 'lib/sidekiq_unique_jobs/lock'
   add_group 'Server', 'lib/sidekiq_unique_jobs/server'

--- a/Guardfile
+++ b/Guardfile
@@ -34,6 +34,7 @@ guard :rspec, cmd: "env COV=false bundle exec rspec" do
   rspec = dsl.rspec
   watch(%r{^lib/(.+)\.rb$}) { |m| "spec/unit/#{m[1]}_spec.rb" }
   watch(%r{^lib/(.+)\.rb$}) { |m| "spec/integration/#{m[1]}_spec.rb" }
+  watch(%r{^examples/(.+)\.rb$}) { |m| "spec/examples/#{m[1]}_spec.rb" }
   watch(rspec.spec_helper)  { rspec.spec_dir }
   watch(rspec.spec_support) { rspec.spec_dir }
   watch(rspec.spec_files)

--- a/examples/until_and_while_executing_job.rb
+++ b/examples/until_and_while_executing_job.rb
@@ -5,7 +5,7 @@
 class UntilAndWhileExecutingJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :working, unique: :until_and_while_executing, lock_timeout: 1
+  sidekiq_options queue: :working, unique: :until_and_while_executing, lock_timeout: 0
 
   def perform(one)
     [one]

--- a/examples/until_expired_job.rb
+++ b/examples/until_expired_job.rb
@@ -4,7 +4,7 @@
 
 class UntilExpiredJob
   include Sidekiq::Worker
-  sidekiq_options unique: :until_expired, lock_expiration: 10 * 60
+  sidekiq_options unique: :until_expired, lock_expiration: 1, lock_timeout: 0
 
   def perform(one)
     TestClass.run(one)

--- a/lib/sidekiq_unique_jobs/cli.rb
+++ b/lib/sidekiq_unique_jobs/cli.rb
@@ -40,10 +40,6 @@ module SidekiqUniqueJobs
     end
 
     no_commands do
-      def logger
-        SidekiqUniqueJobs.logger
-      end
-
       def console_class
         require 'pry'
         Pry

--- a/lib/sidekiq_unique_jobs/lock/until_expired.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_expired.rb
@@ -8,6 +8,7 @@ module SidekiqUniqueJobs
       end
 
       def execute(callback)
+        return unless locked?
         yield if block_given?
         callback.call
       end

--- a/lib/sidekiq_unique_jobs/unique_args.rb
+++ b/lib/sidekiq_unique_jobs/unique_args.rb
@@ -79,14 +79,12 @@ module SidekiqUniqueJobs
       when Symbol
         filter_by_symbol(json_args)
       else
-        log_debug { "#{__method__} arguments not filtered (using all arguments for uniqueness)" }
+        log_debug("#{__method__} arguments not filtered (using all arguments for uniqueness)")
         json_args
       end
     end
 
     def filter_by_proc(args)
-      return args if unique_args_method.nil?
-
       unique_args_method.call(args)
     end
 
@@ -95,7 +93,7 @@ module SidekiqUniqueJobs
 
       worker_class.send(unique_args_method, args)
     rescue ArgumentError => ex
-      log_fatal ex
+      log_fatal(ex)
       args
     end
 

--- a/lib/sidekiq_unique_jobs/unlockable.rb
+++ b/lib/sidekiq_unique_jobs/unlockable.rb
@@ -13,9 +13,5 @@ module SidekiqUniqueJobs
       SidekiqUniqueJobs::UniqueArgs.digest(item)
       SidekiqUniqueJobs::Locksmith.new(item).delete!
     end
-
-    def logger
-      SidekiqUniqueJobs.logger
-    end
   end
 end

--- a/lib/sidekiq_unique_jobs/util.rb
+++ b/lib/sidekiq_unique_jobs/util.rb
@@ -62,11 +62,6 @@ module SidekiqUniqueJobs
       Time.now
     end
 
-    def prefix_keys(keys)
-      keys = Array(keys).compact
-      keys.map { |key| prefix(key) }
-    end
-
     def prefix(key)
       return key if unique_prefix.nil?
       return key if key.start_with?("#{unique_prefix}:")

--- a/spec/examples/until_expired_job_spec.rb
+++ b/spec/examples/until_expired_job_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe UntilExpiredJob do
   it_behaves_like 'sidekiq with options' do
     let(:options) do
       {
-        'lock_expiration' => 600,
+        'lock_expiration' => 1,
+        'lock_timeout' => 0,
         'retry'           => true,
         'unique'          => :until_expired,
       }

--- a/spec/integration/sidekiq_unique_jobs/lock/until_expired_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/lock/until_expired_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SidekiqUniqueJobs::Lock::UntilExpired, redis: :redis do
+  include SidekiqHelpers
+
+  let(:process_one) { described_class.new(item_one) }
+  let(:process_two) { described_class.new(item_two) }
+
+  let(:jid_one)      { 'jid one' }
+  let(:jid_two)      { 'jid two' }
+  let(:worker_class) { UntilExpiredJob }
+  let(:unique)       { :until_expired }
+  let(:queue)        { :rejecting }
+  let(:args)         { %w[array of arguments] }
+  let(:callback)     { -> {} }
+  let(:item_one) do
+    { 'jid' => jid_one,
+      'class' => worker_class.to_s,
+      'queue' => queue,
+      'unique' => unique,
+      'args' => args }
+  end
+  let(:item_two) do
+    { 'jid' => jid_two,
+      'class' => worker_class.to_s,
+      'queue' => queue,
+      'unique' => unique,
+      'args' => args }
+  end
+
+  before do
+    allow(callback).to receive(:call).and_call_original
+  end
+
+  describe '#execute' do
+    it 'process one can be locked' do
+      expect(process_one.lock).to eq(jid_one)
+      expect(process_one.locked?).to eq(true)
+    end
+
+    context 'when process one has locked the job' do
+      before do
+        process_one.lock
+      end
+
+      it 'process two cannot achieve a lock' do
+        expect(process_two.lock).to eq(nil)
+      end
+
+      it 'process two cannot execute the lock' do
+        unset = true
+        process_two.execute(callback) do
+          unset = false
+        end
+
+        expect(unset).to eq(true)
+      end
+
+      it 'process one can execute the job' do
+        set = false
+        process_one.execute(callback) do
+          set = true
+        end
+
+        expect(set).to eq(true)
+      end
+
+      it 'the job is still locked after executing' do
+        process_one.execute(callback) {}
+
+        expect(process_one.locked?).to eq(true)
+      end
+
+      it 'calls back' do
+        process_one.execute(callback) do
+          # NO OP
+        end
+
+        expect(callback).to have_received(:call)
+      end
+
+      it 'prevents ' do
+      end
+
+      it 'callbacks are only called once (for the locked process)' do
+        process_one.execute(callback) do
+          process_two.execute(callback) {}
+        end
+
+        expect(callback).to have_received(:call).once
+      end
+    end
+  end
+end

--- a/spec/integration/sidekiq_unique_jobs/lock/until_expired_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/lock/until_expired_spec.rb
@@ -90,4 +90,17 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilExpired, redis: :redis do
       end
     end
   end
+
+  describe '#unlock' do
+    context 'when lock is locked' do
+      before { process_one.lock }
+
+      it 'keeps the lock even when unlocking' do
+        expect(process_one.unlock).to eq(true)
+        expect(process_one.locked?).to eq(true)
+      end
+    end
+
+    it { expect(process_one.unlock).to eq(true) }
+  end
 end

--- a/spec/integration/sidekiq_unique_jobs/lock/until_expired_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/lock/until_expired_spec.rb
@@ -81,9 +81,6 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilExpired, redis: :redis do
         expect(callback).to have_received(:call)
       end
 
-      it 'prevents ' do
-      end
-
       it 'callbacks are only called once (for the locked process)' do
         process_one.execute(callback) do
           process_two.execute(callback) {}

--- a/spec/integration/sidekiq_unique_jobs/lock/while_executing_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/lock/while_executing_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting, redis: :redis do
+  include SidekiqHelpers
+
+  let(:process_one) { described_class.new(item_one) }
+  let(:process_two) { described_class.new(item_two) }
+
+  let(:jid_one)      { 'jid one' }
+  let(:jid_two)      { 'jid two' }
+  let(:worker_class) { WhileExecutingRejectJob }
+  let(:unique)       { :while_executing_reject }
+  let(:queue)        { :rejecting }
+  let(:args)         { %w[array of arguments] }
+  let(:callback)     { -> {} }
+  let(:item_one) do
+    { 'jid' => jid_one,
+      'class' => worker_class.to_s,
+      'queue' => queue,
+      'unique' => unique,
+      'args' => args }
+  end
+  let(:item_two) do
+    { 'jid' => jid_two,
+      'class' => worker_class.to_s,
+      'queue' => queue,
+      'unique' => unique,
+      'args' => args }
+  end
+
+  before do
+    allow(callback).to receive(:call).and_call_original
+  end
+
+  describe '#execute' do
+    it 'does not lock jobs' do
+      expect(process_one.lock).to eq(true)
+      expect(process_one.locked?).to eq(false)
+
+      expect(process_two.lock).to eq(true)
+      expect(process_two.locked?).to eq(false)
+    end
+
+    context 'when job is executing' do
+      it 'locks the process' do
+        process_one.execute(callback) do
+          expect(process_one.locked?).to eq(true)
+        end
+      end
+
+      it 'calls back' do
+        process_one.execute(callback) do
+          # NO OP
+        end
+        expect(callback).to have_received(:call)
+      end
+
+      it 'prevents other processes from executing' do
+        process_one.execute(callback) do
+          expect(process_two.lock).to eq(true)
+          expect(process_two.locked?).to eq(false)
+          unset = true
+          process_two.execute(callback) do
+            unset = false
+          end
+          expect(unset).to eq(true)
+        end
+
+        expect(callback).to have_received(:call).once
+      end
+    end
+  end
+end

--- a/spec/integration/sidekiq_unique_jobs/lock/while_executing_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/lock/while_executing_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting, redis: :redis do
 
   let(:jid_one)      { 'jid one' }
   let(:jid_two)      { 'jid two' }
-  let(:worker_class) { WhileExecutingRejectJob }
-  let(:unique)       { :while_executing_reject }
-  let(:queue)        { :rejecting }
+  let(:worker_class) { WhileExecutingJob }
+  let(:unique)       { :while_executing }
+  let(:queue)        { :while_executing }
   let(:args)         { %w[array of arguments] }
   let(:callback)     { -> {} }
   let(:item_one) do

--- a/spec/unit/sidekiq_unique_jobs/cli_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/cli_spec.rb
@@ -18,9 +18,10 @@ RSpec.describe SidekiqUniqueJobs::Cli, redis: :redis, ruby_ver: '>= 2.4' do
   let(:pattern)       { '*' }
 
   describe '#help' do
-    let(:output) { capture(:stdout) { described_class.start(%w[help]) } }
-    let(:banner) do
-      <<~HEADER
+    subject(:help) { capture(:stdout) { described_class.start(%w[help]) } }
+
+    it 'displays help' do
+      expect(help).to include <<~HEADER
         Commands:
           jobs  console         # drop into a console with easy access to helper methods
           jobs  del PATTERN     # deletes unique keys from redis by pattern
@@ -29,14 +30,11 @@ RSpec.describe SidekiqUniqueJobs::Cli, redis: :redis, ruby_ver: '>= 2.4' do
       HEADER
     end
 
-    it 'displays help' do
-      expect(output).to include(banner)
-    end
-
     describe '#help del' do
-      let(:output) { capture(:stdout) { described_class.start(%w[help del]) } }
-      let(:banner) do
-        <<~HEADER
+      subject(:help) { capture(:stdout) { described_class.start(%w[help del]) } }
+
+      it 'displays help about the `del` command' do
+        expect(help).to eq <<~HEADER
           Usage:
             jobs  del PATTERN
 
@@ -48,16 +46,13 @@ RSpec.describe SidekiqUniqueJobs::Cli, redis: :redis, ruby_ver: '>= 2.4' do
           deletes unique keys from redis by pattern
         HEADER
       end
-
-      it 'displays help about the `del` command' do
-        expect(output).to eq(banner)
-      end
     end
 
     describe '#help keys' do
-      let(:output) { capture(:stdout) { described_class.start(%w[help keys]) } }
-      let(:banner) do
-        <<~HEADER
+      subject(:help) { capture(:stdout) { described_class.start(%w[help keys]) } }
+
+      it 'displays help about the `key` command' do
+        expect(help).to eq <<~HEADER
           Usage:
             jobs  keys PATTERN
 
@@ -68,20 +63,14 @@ RSpec.describe SidekiqUniqueJobs::Cli, redis: :redis, ruby_ver: '>= 2.4' do
           list all unique keys and their expiry time
         HEADER
       end
-
-      it 'displays help about the `key` command' do
-        expect(output).to eq(banner)
-      end
     end
   end
 
   describe '.keys' do
-    let(:output) { capture(:stdout) { described_class.start(%w[keys * --count 1000]) } }
+    subject(:keys) { capture(:stdout) { described_class.start(%w[keys * --count 1000]) } }
 
     context 'when no keys exist' do
-      let(:expected) { "Found 0 keys matching '#{pattern}':\n" }
-
-      specify { expect(output).to eq(expected) }
+      it { is_expected.to eq("Found 0 keys matching '#{pattern}':\n") }
     end
 
     context 'when a key exists' do
@@ -91,47 +80,52 @@ RSpec.describe SidekiqUniqueJobs::Cli, redis: :redis, ruby_ver: '>= 2.4' do
 
       after { SidekiqUniqueJobs::Util.del('*', 1000) }
 
-      specify do
-        expect(output).to include("Found 3 keys matching '*':")
-        expect(output).to include('uniquejobs:abcdefab:EXISTS')
-        expect(output).to include('uniquejobs:abcdefab:GRABBED')
-        expect(output).to include('uniquejobs:abcdefab:GRABBED')
-      end
+      it { is_expected.to include("Found 3 keys matching '*':") }
+      it { is_expected.to include('uniquejobs:abcdefab:EXISTS') }
+      it { is_expected.to include('uniquejobs:abcdefab:GRABBED') }
+      it { is_expected.to include('uniquejobs:abcdefab:VERSION') }
     end
   end
 
   describe '.del' do
-    let(:expected) do
-      <<~HEADER
-        Deleted 3 keys matching '*'
-      HEADER
-    end
+    subject(:del) { capture(:stdout) { described_class.start(args) } }
+
+    let(:args) { %W[del * #{options} --count 1000] }
 
     before do
       SidekiqUniqueJobs::Locksmith.new(item).lock
     end
 
-    specify do
-      output = capture(:stdout) { described_class.start(%w[del * --no-dry-run --count 1000]) }
-      expect(output).to eq(expected)
-      expect(SidekiqUniqueJobs::Util.keys).to eq([])
+    context 'with argument --dry-run' do
+      let(:options) { '--dry-run' }
+
+      specify do
+        expect(del).to eq("Would delete 3 keys matching '*'\n")
+        expect(SidekiqUniqueJobs::Util.keys).not_to eq([])
+      end
+    end
+
+    context 'with argument --no-dry-run' do
+      let(:options) { '--no-dry-run' }
+
+      specify do
+        expect(del).to eq("Deleted 3 keys matching '*'\n")
+        expect(SidekiqUniqueJobs::Util.keys).to eq([])
+      end
     end
   end
 
   describe '.console', ruby_ver: '>= 2.5.1' do
-    let(:expected) do
-      <<~HEADER
-        Use `keys '*', 1000 to display the first 1000 unique keys matching '*'
-        Use `del '*', 1000, true (default) to see how many keys would be deleted for the pattern '*'
-        Use `del '*', 1000, false to delete the first 1000 keys matching '*'
-      HEADER
-    end
-    let(:output) { capture(:stdout) { described_class.start(%w[console]) } }
+    subject(:console) { capture(:stdout) { described_class.start(%w[console]) } }
 
     specify do
       expect(Object).to receive(:include).with(SidekiqUniqueJobs::Util).and_return(true)
       allow(Pry).to receive(:start).and_return(true)
-      expect(output).to eq(expected)
+      expect(console).to eq <<~HEADER
+        Use `keys '*', 1000 to display the first 1000 unique keys matching '*'
+        Use `del '*', 1000, true (default) to see how many keys would be deleted for the pattern '*'
+        Use `del '*', 1000, false to delete the first 1000 keys matching '*'
+      HEADER
     end
   end
 end

--- a/spec/unit/sidekiq_unique_jobs/lock/until_and_while_executing_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/lock/until_and_while_executing_spec.rb
@@ -53,4 +53,19 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilAndWhileExecuting do
       end
     end
   end
+
+  describe '#runtime_lock' do
+    subject(:runtime_lock) { lock.runtime_lock }
+
+    it { is_expected.to be_a(SidekiqUniqueJobs::Lock::WhileExecuting) }
+
+    it 'initializes with the right arguments' do
+      allow(SidekiqUniqueJobs::Lock::WhileExecuting).to receive(:new)
+      runtime_lock
+
+      expect(SidekiqUniqueJobs::Lock::WhileExecuting)
+        .to have_received(:new)
+        .with(item, redis_pool)
+    end
+  end
 end

--- a/spec/unit/sidekiq_unique_jobs/lock/until_expired_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/lock/until_expired_spec.rb
@@ -18,12 +18,35 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilExpired do
     it { is_expected.to eq(true) }
   end
 
+  before do
+    allow(empty_callback).to receive(:call)
+  end
+
   describe '#execute' do
     subject(:execute) { lock.execute(empty_callback) }
 
-    it 'calls the callback' do
-      expect(empty_callback).to receive(:call)
-      execute
+    let(:locked?) { false }
+
+    before do
+      allow(lock).to receive(:locked?).and_return(locked?)
+    end
+
+    context 'when locked?' do
+      let(:locked?) { true }
+
+      it 'calls back' do
+        execute
+
+        expect(empty_callback).to have_received(:call)
+      end
+    end
+
+    context 'when not locked?' do
+      it 'does not call back' do
+        execute
+
+        expect(empty_callback).not_to have_received(:call)
+      end
     end
   end
 end

--- a/spec/unit/sidekiq_unique_jobs/unique_args_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/unique_args_spec.rb
@@ -151,6 +151,31 @@ RSpec.describe SidekiqUniqueJobs::UniqueArgs do
     end
   end
 
+  describe '#filtered_args' do
+    subject(:filtered_args) { unique_args.filtered_args(args) }
+
+    let(:args) { [1, 'test' => 'it'] }
+
+    before do
+      allow(unique_args).to receive(:unique_args_method).and_return(unique_args_method)
+    end
+
+    context 'when #unique_args_method is nil' do
+      let(:unique_args_method) { nil }
+
+      it 'logs a debug message' do
+        allow(unique_args).to receive(:log_debug)
+        filtered_args
+
+        expect(unique_args)
+          .to have_received(:log_debug)
+          .with('filtered_args arguments not filtered (using all arguments for uniqueness)')
+      end
+
+      it { is_expected.to eq(args) }
+    end
+  end
+
   describe '#filter_by_proc' do
     subject(:filter_by_proc) { unique_args.filter_by_proc(args) }
 
@@ -162,12 +187,6 @@ RSpec.describe SidekiqUniqueJobs::UniqueArgs do
       before { allow(unique_args).to receive(:unique_args_method).and_return(filter) }
 
       it { is_expected.to eq('it') }
-    end
-
-    context 'when #unique_args_method is nil' do
-      before { allow(unique_args).to receive(:unique_args_method).and_return(nil) }
-
-      it { is_expected.to eq(args) }
     end
 
     with_default_worker_options(unique_args: ->(args) { args.first }) do

--- a/spec/unit/sidekiq_unique_jobs_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe SidekiqUniqueJobs do
     end
   end
 
+  describe '.logger=' do
+    let(:original_logger) { Sidekiq.logger }
+    let(:another_logger) { Logger.new('/dev/null') }
+
+    it 'changes the SidekiqUniqueJobs.logger' do
+      expect { described_class.logger = another_logger }
+        .to change(described_class, :logger)
+        .from(original_logger)
+        .to(another_logger)
+
+      described_class.logger = original_logger
+    end
+  end
+
   describe '.redis_version' do
     subject(:redis_version) { described_class.redis_version }
 


### PR DESCRIPTION
This should fix the UntilExpired lock (which was clearly broken). It did not prevent locks that where previously not locked from executing.

Also fixes the integration tests for WhileExecuting and attempts to speed up the test suite by not waiting for locks to be released.