### PR TITLE
Only unlock not delete

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/base_lock.rb
+++ b/lib/sidekiq_unique_jobs/lock/base_lock.rb
@@ -63,7 +63,6 @@ module SidekiqUniqueJobs
       def unlock_and_callback(callback)
         return notify_about_manual_unlock unless operative
         unlock
-        delete
 
         return notify_about_manual_unlock if locked?
         callback_safely(callback)

--- a/lib/sidekiq_unique_jobs/unique_args.rb
+++ b/lib/sidekiq_unique_jobs/unique_args.rb
@@ -6,8 +6,6 @@ require 'sidekiq_unique_jobs/normalizer'
 module SidekiqUniqueJobs
   # This class exists to be testable and the entire api should be considered private
   class UniqueArgs
-    CLASS_NAME = 'SidekiqUniqueJobs::UniqueArgs'
-
     include SidekiqUniqueJobs::Logging
     include SidekiqUniqueJobs::SidekiqWorkerMethods
 

--- a/spec/examples/my_unique_job_spec.rb
+++ b/spec/examples/my_unique_job_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe MyUniqueJob do
         described_class.perform_in(3600, 1, 2)
         expect(1).to be_enqueued_in('customqueue')
         expect(1).to be_enqueued_in('schedule')
-        expect(zcount('schedule')).to eq(1)
+        expect(zcard('schedule')).to eq(1)
         expect(1).to be_scheduled_at(Time.now.to_f + 2 * 3600)
       end
 

--- a/spec/examples/my_unique_job_spec.rb
+++ b/spec/examples/my_unique_job_spec.rb
@@ -19,14 +19,18 @@ RSpec.describe MyUniqueJob do
     let(:args) { %w[one two] }
   end
 
-  describe 'client middleware' do
+  describe 'client middleware', redis: :redis do
     context 'when job is delayed' do
       before { described_class.perform_in(3600, 1, 2) }
 
       it 'rejects new scheduled jobs' do
         expect(1).to be_enqueued_in('customqueue')
         described_class.perform_in(3600, 1, 2)
+        described_class.perform_in(3600, 1, 2)
+        described_class.perform_in(3600, 1, 2)
         expect(1).to be_enqueued_in('customqueue')
+        expect(1).to be_enqueued_in('schedule')
+        expect(zcount('schedule')).to eq(1)
         expect(1).to be_scheduled_at(Time.now.to_f + 2 * 3600)
       end
 

--- a/spec/integration/sidekiq_unique_jobs/client/middleware_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/client/middleware_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe SidekiqUniqueJobs::Client::Middleware, redis: :redis, redis_db: 1
     it 'rejects nested subsequent jobs with the same arguments' do
       expect(SimpleWorker.perform_async(1)).not_to eq(nil)
       expect(SimpleWorker.perform_async(1)).to eq(nil)
+      expect(SimpleWorker.perform_in(60, 1)).to eq(nil)
+      expect(SimpleWorker.perform_in(60, 1)).to eq(nil)
+      expect(SimpleWorker.perform_in(60, 1)).to eq(nil)
+      expect(zcard('schedule')).to eq(0)
       expect(SpawnSimpleWorker.perform_async(1)).not_to eq(nil)
 
       expect(queue_count('default')).to eq(1)

--- a/spec/integration/sidekiq_unique_jobs/server/middleware/until_and_while_executing_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/server/middleware/until_and_while_executing_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe SidekiqUniqueJobs::Server::Middleware, 'unique: :until_and_while_
                                                version_key,
                                                available_run_key,
                                                available_key,
+                                               exists_run_key,
+                                               version_run_key,
                                              ])
         end
       end

--- a/spec/support/sidekiq_helpers.rb
+++ b/spec/support/sidekiq_helpers.rb
@@ -11,8 +11,8 @@ module SidekiqHelpers
     redis { |conn| conn.zcard(queue) }
   end
 
-  def zcount(queue, time)
-    redis { |conn| conn.zcount(queue, -1, time) }
+  def zcount(queue, min = '-inf', max = '+inf')
+    redis { |conn| conn.zcount(queue, min, max) }
   end
 
   def hexists(hash, key)
@@ -39,8 +39,8 @@ module SidekiqHelpers
     zcard('schedule')
   end
 
-  def schedule_count_at(time = Time.now.to_f + 2 * 60)
-    zcount('schedule', time)
+  def schedule_count_at(max = Time.now.to_f + 2 * 60)
+    zcount('schedule', '-inf', max)
   end
 
   def queue_count(queue)


### PR DESCRIPTION
We actually don't want to delete the lock. Removing it should be sufficient for the next job to be able to acquire it again.