### PR TITLE
Ruby < 2.3 compatibility

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/base_lock.rb
+++ b/lib/sidekiq_unique_jobs/lock/base_lock.rb
@@ -73,7 +73,8 @@ module SidekiqUniqueJobs
       end
 
       def callback_safely
-        callback&.call
+        return if callback.nil?
+        callback.call
       rescue StandardError
         log_warn("The lock for #{item[UNIQUE_DIGEST_KEY]} has been released but the #after_unlock callback failed!")
         raise

--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -84,7 +84,7 @@ module SidekiqUniqueJobs
 
     def grab_token(timeout = nil)
       redis(redis_pool) do |conn|
-        if timeout.nil? || timeout.positive?
+        if timeout.nil? || timeout > 0
           # passing timeout 0 to blpop causes it to block
           _key, token = conn.blpop(available_key, timeout || 0)
         else

--- a/rails_example/app/workers/while_executing_worker.rb
+++ b/rails_example/app/workers/while_executing_worker.rb
@@ -7,7 +7,7 @@ class WhileExecutingWorker
 
   def perform(sleepy_time)
     sleepy_time = sleepy_time.to_i
-    sleep sleepy_time if sleepy_time.positive?
+    sleep sleepy_time if sleepy_time > 0
     Post.create!(title: "Some Random post that took #{sleepy_time} seconds to create", body: "The job_id was #{jid}")
   end
 end

--- a/sidekiq-unique-jobs.gemspec
+++ b/sidekiq-unique-jobs.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
     end
   end
 
+  spec.required_ruby_version = '>= 2'
+
   spec.require_paths = ['lib']
   spec.add_dependency 'concurrent-ruby', '~> 1.0', '>= 1.0.5'
   spec.add_dependency 'sidekiq', '>= 4.0', '< 6.0'


### PR DESCRIPTION
## Context
As discussed in https://github.com/mhenrixon/sidekiq-unique-jobs/issues/291

## Changes
This PR replaces the references to Ruby 2.3 methods to make the GEM compatible with 2.0 and above.

Also added an explicit `required_ruby_version` in the gemspec to be 2.0 and greater. Looking at the README: `Starting from 5.0.0 [...] support for MRI <= 2.1 is dropped`. Is it safe to relax the Ruby requirement? Note that [Sidekiq 4 requires a minimum of Ruby 2.0](https://github.com/mperham/sidekiq/tree/v4.2.10#requirements)

## Testing
I only tested a `:until_executed`, I need to review the rest of the code to confirm the compatibility. The whole test environment is not passing with Ruby 2.1.10 because of incompatibilities with recent dependencies but other than that the core spec files are passing after those fixes.