### PR TITLE
Fix replace conflict strategy

### DIFF
--- a/lib/sidekiq_unique_jobs/middleware.rb
+++ b/lib/sidekiq_unique_jobs/middleware.rb
@@ -17,11 +17,6 @@ module SidekiqUniqueJobs
 
     def configure_server_middleware
       Sidekiq.configure_server do |config|
-        config.client_middleware do |chain|
-          require 'sidekiq_unique_jobs/client/middleware'
-          chain.add SidekiqUniqueJobs::Client::Middleware
-        end
-
         config.server_middleware do |chain|
           require 'sidekiq_unique_jobs/server/middleware'
           chain.add SidekiqUniqueJobs::Server::Middleware

--- a/lib/sidekiq_unique_jobs/on_conflict.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict.rb
@@ -14,6 +14,7 @@ module SidekiqUniqueJobs
       log: OnConflict::Log,
       raise: OnConflict::Raise,
       reject: OnConflict::Reject,
+      replace: OnConflict::Replace,
       reschedule: OnConflict::Reschedule,
     }.freeze
 

--- a/spec/unit/sidekiq_unique_jobs/middleware_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/middleware_spec.rb
@@ -21,9 +21,6 @@ RSpec.describe SidekiqUniqueJobs::Middleware do
       it 'adds client and server middleware when required' do
         expect(Sidekiq).to receive(:configure_server).and_yield(server_config)
 
-        expect(server_config).to receive(:client_middleware).and_yield(client_middleware)
-        expect(client_middleware).to receive(:add).with(SidekiqUniqueJobs::Client::Middleware)
-
         expect(server_config).to receive(:server_middleware).and_yield(server_middleware)
         expect(server_middleware).to receive(:add).with(SidekiqUniqueJobs::Server::Middleware)
         described_class.configure_server_middleware


### PR DESCRIPTION
After initially failing to get this feature working, I found that the strategy class wasn't in the hash of strategies.

The other thing this PR addresses is removing the client middleware is loaded on the server. 

The client middleware checks if a lock is in place and enqueues in its absense. Client middleware on the server however is only hit when the server enqueues to itself which happens when sidekiq takes scheduled items and enqueues them on the work queue.

I was trying to use the `:until_executing` lock along with `:replace` strategy, but the server would just take the job and drop in `Client::Middleware#call` because the lock only gets released during the server middleware call.

All ears if the client middleware on the server is necessary for whatever other reason.

All the tests pass without it (bar the test which just checks the presence of it, which I fixed).