### PR TITLE
Enable replace strategy

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -58,19 +58,26 @@ detectors:
     - Array
   NilCheck:
     enabled: false
+  DataClump:
+    enabled: true
+    exclude:
+      - SidekiqUniqueJobs::Util
   FeatureEnvy:
     exclude:
-    - SidekiqUniqueJobs::OnConflict::Reject#push_to_deadset
-    - SidekiqUniqueJobs::Logging#debug_item
-    - SidekiqUniqueJobs::Util#batch_delete
     - SidekiqUniqueJobs::Digests#batch_delete
+    - SidekiqUniqueJobs::Digests#page
+    - SidekiqUniqueJobs::Logging#debug_item
+    - SidekiqUniqueJobs::OnConflict::Reject#push_to_deadset
+    - SidekiqUniqueJobs::Util#batch_delete
+    - SidekiqUniqueJobs::Web::Helpers#cparams
   NestedIterators:
     exclude:
+    - SidekiqUniqueJobs::Digests#batch_delete
     - SidekiqUniqueJobs::Locksmith#create_lock
     - SidekiqUniqueJobs::Middleware#configure_client_middleware
     - SidekiqUniqueJobs::Middleware#configure_server_middleware
     - SidekiqUniqueJobs::Util#batch_delete
-    - SidekiqUniqueJobs::Digests#batch_delete
+    - SidekiqUniqueJobs::Util#keys_with_ttl
   TooManyInstanceVariables:
     exclude:
     - SidekiqUniqueJobs::Locksmith

--- a/lib/sidekiq_unique_jobs/lock/base_lock.rb
+++ b/lib/sidekiq_unique_jobs/lock/base_lock.rb
@@ -23,6 +23,7 @@ module SidekiqUniqueJobs
       # @return [String] the sidekiq job id
       def lock
         @attempt = 0
+        return item[JID_KEY] if locked?
 
         if (token = locksmith.lock(item[LOCK_TIMEOUT_KEY]))
           token

--- a/lib/sidekiq_unique_jobs/on_conflict.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict.rb
@@ -14,6 +14,7 @@ module SidekiqUniqueJobs
       log: OnConflict::Log,
       raise: OnConflict::Raise,
       reject: OnConflict::Reject,
+      replace: OnConflict::Replace,
       reschedule: OnConflict::Reschedule,
     }.freeze
 

--- a/lib/sidekiq_unique_jobs/on_conflict/replace.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/replace.rb
@@ -2,7 +2,7 @@
 
 module SidekiqUniqueJobs
   module OnConflict
-    # Strategy to raise an error on conflict
+    # Strategy to replace the job on conflict
     #
     # @author Mikael Henriksson <mikael@zoolutions.se>
     class Replace < OnConflict::Strategy

--- a/lib/sidekiq_unique_jobs/util.rb
+++ b/lib/sidekiq_unique_jobs/util.rb
@@ -23,6 +23,20 @@ module SidekiqUniqueJobs
       redis { |conn| conn.scan_each(match: prefix(pattern), count: count).to_a }
     end
 
+    # Find unique keys with ttl
+    # @param [String] pattern a pattern to scan for in redis
+    # @param [Integer] count the maximum number of keys to delete
+    # @return [Hash<String, Integer>] a hash with active unique keys and corresponding ttl
+    def keys_with_ttl(pattern = SCAN_PATTERN, count = DEFAULT_COUNT)
+      hash = {}
+      redis do |conn|
+        conn.scan_each(match: prefix(pattern), count: count).each do |key|
+          hash[key] = conn.ttl(key)
+        end
+      end
+      hash
+    end
+
     # Deletes unique keys from redis
     #
     # @param [String] pattern a pattern to scan for in redis

--- a/spec/integration/sidekiq_unique_jobs/lock/until_executing_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/lock/until_executing_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SidekiqUniqueJobs::Lock::UntilExecuting, redis: :redis do
+  include SidekiqHelpers
+
+  let(:process_one) { described_class.new(item_one, callback) }
+  let(:process_two) { described_class.new(item_two, callback) }
+
+  let(:jid_one)      { 'jid one' }
+  let(:jid_two)      { 'jid two' }
+  let(:worker_class) { UntilExecutedJob }
+  let(:unique)       { :until_executed }
+  let(:queue)        { :executed }
+  let(:args)         { %w[array of arguments] }
+  let(:callback)     { -> {} }
+  let(:item_one) do
+    { 'jid' => jid_one,
+      'class' => worker_class.to_s,
+      'queue' => queue,
+      'lock' => unique,
+      'args' => args }
+  end
+  let(:item_two) do
+    { 'jid' => jid_two,
+      'class' => worker_class.to_s,
+      'queue' => queue,
+      'lock' => unique,
+      'args' => args }
+  end
+
+  before do
+    allow(callback).to receive(:call).and_call_original
+  end
+
+  describe '#lock' do
+    it_behaves_like 'a lock implementation'
+  end
+
+  describe '#execute' do
+    it 'unlocks before executing' do
+      process_one.lock
+      process_one.execute do
+        expect(process_one.locked?).to eq(false)
+      end
+    end
+  end
+
+  describe '#delete' do
+    subject(:delete) { process_one.delete }
+
+    context 'when locked' do
+      context 'when expiration is not negative' do
+        it 'deletes the lock without fuss' do
+          worker_class.use_options(lock_expiration: nil) do
+            process_one.lock
+            expect { delete }.to change { unique_keys.size }.from(3).to(0)
+          end
+        end
+      end
+
+      context 'when expiration is positive' do
+        it 'does not delete the lock' do
+          worker_class.use_options(lock_expiration: 100) do
+            process_one.lock
+            expect { delete }.not_to change(unique_keys, :size)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#delete!' do
+    subject(:delete!) { process_one.delete! }
+
+    context 'when locked' do
+      before { process_one.lock }
+
+      it 'deletes the lock without fuss' do
+        expect { delete! }.to change { unique_keys.size }.from(3).to(0)
+      end
+    end
+  end
+end

--- a/spec/unit/sidekiq_unique_jobs/lock/base_lock_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/lock/base_lock_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe SidekiqUniqueJobs::Lock::BaseLock do
   describe '#lock' do
     subject(:lock_lock) { lock.lock }
 
-
     context 'when already locked?' do
       before do
         allow(lock).to receive(:locked?).and_return(true)

--- a/spec/unit/sidekiq_unique_jobs/lock/base_lock_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/lock/base_lock_spec.rb
@@ -26,20 +26,32 @@ RSpec.describe SidekiqUniqueJobs::Lock::BaseLock do
   describe '#lock' do
     subject(:lock_lock) { lock.lock }
 
-    before do
-      allow(locksmith).to receive(:lock).with(kind_of(Integer)).and_return(token)
+
+    context 'when already locked?' do
+      before do
+        allow(lock).to receive(:locked?).and_return(true)
+      end
+
+      it { is_expected.to eq('maaaahjid') }
     end
 
-    context 'when a token is retrieved' do
-      let(:token) { 'another jid' }
+    context 'when not locked?' do
+      before do
+        allow(lock).to receive(:locked?).and_return(false)
+        allow(locksmith).to receive(:lock).with(kind_of(Integer)).and_return(token)
+      end
 
-      it { is_expected.to eq('another jid') }
-    end
+      context 'when a token is retrieved' do
+        let(:token) { 'another jid' }
 
-    context 'when token is not retrieved' do
-      let(:token) { nil }
+        it { is_expected.to eq('another jid') }
+      end
 
-      it { is_expected.to eq(nil) }
+      context 'when token is not retrieved' do
+        let(:token) { nil }
+
+        it { is_expected.to eq(nil) }
+      end
     end
   end
 

--- a/spec/unit/sidekiq_unique_jobs/on_conflict_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/on_conflict_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SidekiqUniqueJobs::OnConflict do
+  describe '::STRAGEGIES' do
+    subject { described_class::STRATEGIES }
+
+    let(:expected) do
+      {
+        log: described_class::Log,
+        raise: described_class::Raise,
+        reject: described_class::Reject,
+        replace: described_class::Replace,
+        reschedule: described_class::Reschedule,
+      }
+    end
+
+    it { is_expected.to eq(expected) }
+  end
+end


### PR DESCRIPTION
Adds coverage for the strategies hash. In the future adding a new strategy should tell us we need to also enable the strategy.

Close #314 