### PR TITLE
Unlock instead of signal

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/base_lock.rb
+++ b/lib/sidekiq_unique_jobs/lock/base_lock.rb
@@ -42,7 +42,7 @@ module SidekiqUniqueJobs
       # @return [String] sidekiq job id when successful
       # @return [false] when unsuccessful
       def unlock
-        locksmith.signal(item[JID_KEY]) # Only signal to release the lock
+        locksmith.unlock(item[JID_KEY]) # Only signal to release the lock
       end
 
       # Deletes the job from redis if it is locked.

--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -91,9 +91,9 @@ module SidekiqUniqueJobs
     # Removes the lock keys from Redis
     # @return [false] unless locked?
     # @return [String] Sidekiq job_id (jid) if successful
-    def unlock
-      return false unless locked?
-      signal(jid)
+    def unlock(token = nil)
+      return false unless locked?(token)
+      signal(token)
     end
 
     # Checks if this instance is considered locked

--- a/redis/signal.lua
+++ b/redis/signal.lua
@@ -18,6 +18,14 @@ if expiration then
   redis.call('EXPIRE', available_key, expiration)
   redis.call('EXPIRE', version_key, expiration)
   redis.call('EXPIRE', unique_digest, expiration) -- TODO: Legacy support (Remove in v6.1)
+else
+  redis.call('DEL', exists_key)
+  redis.call('SREM', unique_keys, unique_digest)
+  redis.call('DEL', grabbed_key)
+  redis.call('DEL', available_key)
+  redis.call('DEL', version_key)
+  redis.call('DEL', 'uniquejobs')   -- TODO: Old job hash, just drop the darn thing
+  redis.call('DEL', unique_digest)  -- TODO: Legacy support (Remove in v6.1)
 end
 
 return available_count

--- a/redis/signal.lua
+++ b/redis/signal.lua
@@ -14,6 +14,7 @@ local available_count = redis.call('LPUSH', available_key, token)
 
 if expiration then
   redis.log(redis.LOG_DEBUG, "signal_locks.lua - expiring stale locks")
+  redis.call('SREM', unique_keys, unique_digest)
   redis.call('EXPIRE', exists_key, expiration)
   redis.call('EXPIRE', available_key, expiration)
   redis.call('EXPIRE', version_key, expiration)

--- a/spec/integration/sidekiq_unique_jobs/legacy_lock_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/legacy_lock_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SidekiqUniqueJobs::Locksmith, redis: :redis do
       it 'can signal to expire the lock after 10' do
         locksmith_one.signal(jid_one)
 
-        expect(ttl(unique_digest)).to eq(-1) # key exists but has been expired
+        expect(ttl(unique_digest)).to eq(-2) # key does not exist anymore
       end
 
       it 'can soft delete the lock' do

--- a/spec/integration/sidekiq_unique_jobs/server/middleware/until_and_while_executing_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/server/middleware/until_and_while_executing_spec.rb
@@ -55,14 +55,7 @@ RSpec.describe SidekiqUniqueJobs::Server::Middleware, 'unique: :until_and_while_
         it 'item_one can be executed by server' do
           expect(unique_keys).to match_array([grabbed_key, exists_key, version_key])
           server.call(worker_class, item_one, queue) {}
-          expect(unique_keys).to match_array([
-                                               exists_key,
-                                               version_key,
-                                               available_run_key,
-                                               available_key,
-                                               exists_run_key,
-                                               version_run_key,
-                                             ])
+          expect(unique_keys).to match_array([])
         end
       end
     end

--- a/spec/unit/sidekiq_unique_jobs/lock/base_lock_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/lock/base_lock_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SidekiqUniqueJobs::Lock::BaseLock do
     subject(:unlock) { lock.unlock }
 
     before do
-      allow(locksmith).to receive(:signal).with(item['jid']).and_return('unlocked')
+      allow(locksmith).to receive(:unlock).with(item['jid']).and_return('unlocked')
     end
 
     it { is_expected.to eq('unlocked') }

--- a/spec/unit/sidekiq_unique_jobs/sidekiq_unique_ext_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/sidekiq_unique_ext_spec.rb
@@ -52,11 +52,7 @@ RSpec.describe 'Sidekiq::Api', redis: :redis do
           )
         end
       end
-      expect(unique_keys).to match_array([
-                                           'uniquejobs:863b7cb639bd71c828459b97788b2ada:AVAILABLE',
-                                           'uniquejobs:863b7cb639bd71c828459b97788b2ada:EXISTS',
-                                           'uniquejobs:863b7cb639bd71c828459b97788b2ada:VERSION',
-                                         ])
+      expect(unique_keys).to match_array([])
       expect(JustAWorker.perform_in(60 * 60 * 3, boo: 'far')).to be_truthy
     end
   end
@@ -66,11 +62,7 @@ RSpec.describe 'Sidekiq::Api', redis: :redis do
       jid = JustAWorker.perform_async(roo: 'baf')
       expect(keys).not_to match_array([])
       Sidekiq::Queue.new('testqueue').find_job(jid).delete
-      expect(unique_keys).to match_array([
-                                           'uniquejobs:c2253601bbfe4f3ad300103026ed02f2:AVAILABLE',
-                                           'uniquejobs:c2253601bbfe4f3ad300103026ed02f2:EXISTS',
-                                           'uniquejobs:c2253601bbfe4f3ad300103026ed02f2:VERSION',
-                                         ])
+      expect(unique_keys).to match_array([])
     end
   end
 
@@ -79,11 +71,7 @@ RSpec.describe 'Sidekiq::Api', redis: :redis do
       JustAWorker.perform_async(oob: 'far')
       expect(keys).not_to match_array([])
       Sidekiq::Queue.new('testqueue').clear
-      expect(unique_keys).to match_array([
-                                           'uniquejobs:ebd23329089b53ea1e93066a3365541f:AVAILABLE',
-                                           'uniquejobs:ebd23329089b53ea1e93066a3365541f:EXISTS',
-                                           'uniquejobs:ebd23329089b53ea1e93066a3365541f:VERSION',
-                                         ])
+      expect(unique_keys).to match_array([])
     end
   end
 
@@ -92,11 +80,7 @@ RSpec.describe 'Sidekiq::Api', redis: :redis do
       JustAWorker.perform_in(60 * 60 * 3, roo: 'fab')
       expect(keys).not_to match_array([])
       Sidekiq::JobSet.new('schedule').clear
-      expect(unique_keys).to match_array([
-                                           'uniquejobs:a88de37817cb5da99cf76408c7251a1d:AVAILABLE',
-                                           'uniquejobs:a88de37817cb5da99cf76408c7251a1d:EXISTS',
-                                           'uniquejobs:a88de37817cb5da99cf76408c7251a1d:VERSION',
-                                         ])
+      expect(unique_keys).to match_array([])
     end
   end
 end


### PR DESCRIPTION
- This will only remove the lock for the job that owns the lock.
- It will leave no leftovers in Redis.