### PR TITLE
Display log message when silently ignoring an unlocked job (UntilExecuted)

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -13,11 +13,10 @@ module SidekiqUniqueJobs
       # Executes in the Sidekiq server process
       # @yield to the worker class perform method
       def execute
-        unless locked?
-          log_warn("the unique_key: #{item[UNIQUE_DIGEST_KEY]} is not locked, allowing job to silently complete")
-          return
-        else
+        if locked?
           with_cleanup { yield }
+        else
+          log_warn("the unique_key: #{item[UNIQUE_DIGEST_KEY]} is not locked, allowing job to silently complete")
         end
       end
     end

--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -13,8 +13,12 @@ module SidekiqUniqueJobs
       # Executes in the Sidekiq server process
       # @yield to the worker class perform method
       def execute
-        return unless locked?
-        with_cleanup { yield }
+        unless locked?
+          log_warn("the unique_key: #{item[UNIQUE_DIGEST_KEY]} is not locked, allowing job to silently complete")
+          return
+        else
+          with_cleanup { yield }
+        end
       end
     end
   end


### PR DESCRIPTION
I was trying to understand why lots of the same jobs were being executed, but nothing was actually executing:

```
JOB: start
JOB: done: 0.123 sec
JOB: start
JOB: done: 0.123 sec
```

This commit adds a log notice so that devs won't be as confused when jobs are skipped because they're currently locked. e.g.:

```
2018-08-07T23:09:45.136Z 17632 TID-15jnuk Addresses::MyWorker JID-d19b97f070a5bf3bc76b1efa INFO: start
2018-08-07T23:09:45.188Z 17632 TID-15jnuk Addresses::MyWorker JID-d19b97f070a5bf3bc76b1efa WARN: the unique_key: uniquejobs:b271dc3da8a75ef21ed92361af976946 is not locked, allowing job to silently complete
2018-08-07T23:09:45.188Z 17632 TID-15jnuk Addresses::MyWorker JID-d19b97f070a5bf3bc76b1efa INFO: done: 0.052 sec
```