### PR TITLE
fix readme testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ RSpec.describe Workers::CoolOne do
 
     it 'prevents duplicate jobs from being scheduled' do
       SidekiqUniqueJobs.use_config(enabled: true) do
-        expect(described_class.perform_async(1)).not_to eq(nil)
+        expect(described_class.perform_in(3600, 1)).not_to eq(nil)
         expect(described_class.perform_async(1)).to eq(nil)
       end
     end


### PR DESCRIPTION
In the Testing section of the `README.md` has a test example as bellow:

```
it 'prevents duplicate jobs from being scheduled' do
  SidekiqUniqueJobs.use_config(enabled: true) do
    expect(described_class.perform_async(1)).not_to eq(nil)
    expect(described_class.perform_async(1)).to eq(nil)
  end
end
```

The problem is if the first `perform_async` runs quickly before the second, the test will not pass.
In another application I had problems performing the tests this way, being that only sometimes the test passed.
Changing the first `expect` with `perform_in` the result is as expected.