### PR TITLE
Do not build keys on lua scripts

### DIFF
--- a/lib/sidekiq_unique_jobs/constants.rb
+++ b/lib/sidekiq_unique_jobs/constants.rb
@@ -19,4 +19,6 @@ module SidekiqUniqueJobs
   ON_CONFLICT_KEY           ||= 'on_conflict'
   UNIQUE_ON_ALL_QUEUES_KEY  ||= 'unique_on_all_queues' # TODO: Remove in v6.1
   UNIQUE_PREFIX_KEY         ||= 'unique_prefix'
+  RETRY_SET                 ||= 'retry'
+  SCHEDULE_SET              ||= 'schedule'
 end

--- a/lib/sidekiq_unique_jobs/on_conflict/replace.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/replace.rb
@@ -25,7 +25,11 @@ module SidekiqUniqueJobs
 
       # Delete the job from either schedule, retry or the queue
       def delete_job_by_digest
-        Scripts.call(:delete_job_by_digest, nil, keys: [queue, unique_digest])
+        Scripts.call(
+          :delete_job_by_digest,
+          nil,
+          keys: ["#{QUEUE_KEY}:#{queue}", SCHEDULE_SET, RETRY_SET], argv: [unique_digest]
+        )
       end
 
       # Delete the keys belonging to the job

--- a/redis/delete_job_by_digest.lua
+++ b/redis/delete_job_by_digest.lua
@@ -1,5 +1,7 @@
-local queue         = "queue:" .. KEYS[1]
-local unique_digest = KEYS[2]
+local queue         = KEYS[1]
+local schedule_set  = KEYS[2]
+local retry_set     = KEYS[3]
+local unique_digest = ARGV[1]
 
 local function delete_from_sorted_set(name, digest)
   local per   = 50
@@ -49,10 +51,10 @@ if result then
   return result
 end
 
-result = delete_from_sorted_set('schedule', unique_digest)
+result = delete_from_sorted_set(schedule_set, unique_digest)
 if result then
   return result
 end
 
-result = delete_from_sorted_set('retry', unique_digest)
+result = delete_from_sorted_set(retry_set, unique_digest)
 return result

--- a/spec/examples/my_unique_job_spec.rb
+++ b/spec/examples/my_unique_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe MyUniqueJob do
         described_class.perform_in(3600, 1, 2)
         expect(1).to be_enqueued_in('customqueue')
         expect(1).to be_enqueued_in('schedule')
-        expect(zcard('schedule')).to eq(1)
+        expect(schedule_count).to eq(1)
         expect(1).to be_scheduled_at(Time.now.to_f + 2 * 3600)
       end
 

--- a/spec/integration/sidekiq_unique_jobs/client/middleware_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/client/middleware_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SidekiqUniqueJobs::Client::Middleware, redis: :redis, redis_db: 1
       jid = NotifyWorker.perform_in(1, 183, 'xxxx')
       expect(jid).not_to eq(nil)
 
-      expect(zcard('schedule')).to eq(1)
+      expect(schedule_count).to eq(1)
 
       expected = %w[
         uniquejobs:6e47d668ad22db2a3ba0afd331514ce2:EXISTS
@@ -23,7 +23,7 @@ RSpec.describe SidekiqUniqueJobs::Client::Middleware, redis: :redis, redis_db: 1
       expect(SimpleWorker.perform_in(60, 1)).to eq(nil)
       expect(SimpleWorker.perform_in(60, 1)).to eq(nil)
       expect(SimpleWorker.perform_in(60, 1)).to eq(nil)
-      expect(zcard('schedule')).to eq(0)
+      expect(schedule_count).to eq(0)
       expect(SpawnSimpleWorker.perform_async(1)).not_to eq(nil)
 
       expect(queue_count('default')).to eq(1)


### PR DESCRIPTION
### Problem

Our one of our projects we're using redis-namespace which below 2.0 try to implicitly namespace keys transparently.

For example for script calls it does the following as an example:

https://github.com/resque/redis-namespace/blob/30d42177d8abfdf89e502c1a98aab7d923c2a133/lib/redis/namespace.rb#L372

Well, we're going to evaluate keeping using redis-namespace on the future, but we cannot afford the migration right now, and we realized that we cannot make use of the new `conflict` resolution features because of this:

https://github.com/mhenrixon/sidekiq-unique-jobs/blob/9d1ee6c29b06b84b82ef3fc136317494b2e961d0/redis/delete_job_by_digest.lua#L1

As it's going to build a string just like `queue:default` when in our redis service should be `app_name:queue:default`

### Solution

We provided a slightly change so the ruby code provides which it thinks is the whole key to search for jobs then `redis-namespace` will add the namespace transparently.

Please let me know what you think, maybe we should add some kind of not on README about the `redis-namespace` usage or any other thing to clarify the previous situation and if this is accepted in some way evaluate if it's correct or not.