### PR TITLE
update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v6.0.7
+
+-  Fix a bug leaving jobs locked ([#352](https://github.com/mhenrixon/sidekiq-unique-jobs/issues/352))
+
 ## v6.0.6
 
 - Fixes a bug with the command line utility ([#321](https://github.com/mhenrixon/sidekiq-unique-jobs/pull/321))


### PR DESCRIPTION
include the latest fixes in release v6.0.7 available via a new gem release. 

This should help automated dependency systems catch the newly cut gem.