### PR TITLE
Log job silently complete

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -13,9 +13,12 @@ module SidekiqUniqueJobs
       # Executes in the Sidekiq server process
       # @yield to the worker class perform method
       def execute
-        return unless locked?
-
-        with_cleanup { yield }
+        if locked?
+          with_cleanup { yield }
+        else
+          log_warn "the unique_key: #{item[UNIQUE_DIGEST_KEY]} is not locked, allowing job to silently complete"
+          nil
+        end
       end
     end
   end

--- a/sidekiq-unique-jobs.gemspec
+++ b/sidekiq-unique-jobs.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://mhenrixon.github.io/sidekiq-unique-jobs"
   spec.license     = "MIT"
   spec.summary     = <<~SUMMARY
-                       Sidekiq middleware that prevents duplicates jobs
-                     SUMMARY
+    Sidekiq middleware that prevents duplicates jobs
+  SUMMARY
   spec.description = <<~DESCRIPTION
-                       Prevents simultaneous Sidekiq jobs with the same unique arguments to run.
-                       Highly configurable to suite your specific needs.
-                     DESCRIPTION
+    Prevents simultaneous Sidekiq jobs with the same unique arguments to run.
+    Highly configurable to suite your specific needs.
+  DESCRIPTION
 
   if spec.respond_to?(:metadata)
     spec.metadata["homepage_uri"]      = spec.homepage
@@ -53,10 +53,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop", "~> 0.9"
 
   # ===== Documentation =====
-  spec.add_development_dependency "yard",          "~> 0.9.18"
-  spec.add_development_dependency "redcarpet",     "~> 3.4"
   spec.add_development_dependency "github-markup", "~> 3.0"
   spec.add_development_dependency "github_changelog_generator", "~> 1.14"
+  spec.add_development_dependency "redcarpet", "~> 3.4"
+  spec.add_development_dependency "yard", "~> 0.9.18"
 
   # ===== Release Management =====
   spec.add_development_dependency "gem-release", ">= 2.0"

--- a/spec/unit/sidekiq_unique_jobs/lock/until_executed_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/lock/until_executed_spec.rb
@@ -18,12 +18,24 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilExecuted do
     it_behaves_like "an executing lock with error handling" do
       context "when not initially locked?" do
         let(:initially_locked?) { false }
+        let(:unique_digest) { "uniquejobs:1b9f2f0624489ccf4e07ac88beae6ce0" }
 
         it "returns without yielding" do
           execute
 
           expect(callback).not_to have_received(:call)
           expect(block).not_to have_received(:call)
+        end
+
+        it "logs the digest key locking the job" do
+          execute
+
+          expect(lock).to have_received(:log_warn)
+            .with("the unique_key: #{unique_digest} is not locked, allowing job to silently complete")
+        end
+
+        it "returns nil" do
+          expect(execute).to be nil
         end
       end
 


### PR DESCRIPTION
Borrows heavily from https://github.com/mhenrixon/sidekiq-unique-jobs/pull/320
with the objective to get this highly useful log shipped to master. 

The problem, as described, is that on a surface a job successfully completes where in fact it wasn't executed at all, due to a lock. 
This commit adds some clarity in the form of a log message explaining that the job did complete silently.

For more info check https://github.com/mhenrixon/sidekiq-unique-jobs/pull/320#issue-206853114