### PR TITLE
Until and while executing should allow job retry

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
@@ -16,9 +16,8 @@ module SidekiqUniqueJobs
       # Executes in the Sidekiq server process
       # @yield to the worker class perform method
       def execute
-        return unless locked?
+        unlock if locked?
 
-        unlock
         runtime_lock.execute { yield }
       end
 

--- a/spec/integration/sidekiq_unique_jobs/lock/until_and_while_executing_spec.rb
+++ b/spec/integration/sidekiq_unique_jobs/lock/until_and_while_executing_spec.rb
@@ -36,7 +36,21 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilAndWhileExecuting, redis: :redis, r
     allow(process_two).to receive(:runtime_lock).and_return(runtime_two)
   end
 
-  it_behaves_like "a lock implementation"
+  it "can be locked" do
+    expect(process_one.lock).to eq(jid_one)
+  end
+
+  context "when process one has locked the job" do
+    before { process_one.lock }
+
+    it "has locked process_one" do
+      expect(process_one).to be_locked
+    end
+
+    it "prevents process_two from locking" do
+      expect(process_two.lock).to eq(nil)
+    end
+  end
 
   it "has not locked runtime_one" do
     process_one.lock

--- a/spec/unit/sidekiq_unique_jobs/lock/until_and_while_executing_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/lock/until_and_while_executing_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilAndWhileExecuting do
       it "unlocks the unique key before yielding" do
         inside_block_value = false
         lock.execute { inside_block_value = true }
-        expect(inside_block_value).to eq(false)
+        expect(inside_block_value).to eq(true)
 
         expect(lock).to have_received(:locked?)
         expect(lock).not_to have_received(:unlock)
-        expect(runtime_lock).not_to have_received(:execute)
+        expect(runtime_lock).to have_received(:execute)
       end
     end
   end


### PR DESCRIPTION
If a job needs to be retried - either because the worker was killed and super fetch retrieved it or the worker raised an exception and was moved to the RetrySet - the `UntilAndWhileExecuting` lock causes the job to be discarded. This is because the lock created by the client middleware no longer exists and the server middleware actively checks that it is still in place and otherwise exits.

In this PR we are changing it so that we do run the worker even after the client lock was wiped out.