### PR TITLE
Bump ruby versions in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,20 +27,20 @@ script:
 after_script:
   - if [[ "${COV}" = "true" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi;
 rvm:
-  - 2.6.2
-  - 2.4.6
+  - 2.6.4
+  - 2.4.7
   - jruby-9.2.7.0
 
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.5.5
+    - rvm: 2.5.6
       gemfile: gemfiles/sidekiq_6.0.gemfile
     - rvm: truffleruby
       gemfile: gemfiles/sidekiq_6.0.gemfile
-    - rvm: 2.6.2
+    - rvm: 2.6.4
       gemfile: gemfiles/sidekiq_develop.gemfile
-    - rvm: 2.6.2
+    - rvm: 2.6.4
       gemfile: gemfiles/sidekiq_6.0.gemfile
       env: COV=true
 


### PR DESCRIPTION
Reference:
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-6-4-released/
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-5-6-released/
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-4-7-released/