### PR TITLE
Fix keyword arguments warnings in Ruby 2.7.0-preview2

### DIFF
--- a/lib/sidekiq_unique_jobs/sidekiq_unique_jobs.rb
+++ b/lib/sidekiq_unique_jobs/sidekiq_unique_jobs.rb
@@ -206,7 +206,7 @@ module SidekiqUniqueJobs
   # @return [Boolean]
   #
   def validate_worker(options)
-    raise NotUniqueWorker, options: options unless (lock_type = options[LOCK])
+    raise NotUniqueWorker.new(options: options) unless (lock_type = options[LOCK])
 
     lock_class = locks[lock_type]
     lock_class.validate_options(options)

--- a/lib/sidekiq_unique_jobs/unique_args.rb
+++ b/lib/sidekiq_unique_jobs/unique_args.rb
@@ -127,10 +127,11 @@ module SidekiqUniqueJobs
 
       worker_class.send(unique_args_method, args)
     rescue ArgumentError
-      raise SidekiqUniqueJobs::InvalidUniqueArguments,
-            given: args,
-            worker_class: worker_class,
-            unique_args_method: unique_args_method
+      raise SidekiqUniqueJobs::InvalidUniqueArguments.new(
+        given: args,
+        worker_class: worker_class,
+        unique_args_method: unique_args_method,
+      )
     end
 
     # The method to use for filtering unique arguments

--- a/lib/sidekiq_unique_jobs/web.rb
+++ b/lib/sidekiq_unique_jobs/web.rb
@@ -26,7 +26,7 @@ module SidekiqUniqueJobs
         @current_cursor = params[:cursor]
         @prev_cursor    = params[:prev_cursor]
         @pagination     = { pattern: @filter, cursor: @current_cursor, page_size: @count }
-        @total_size, @next_cursor, @locks = digests.page(@pagination)
+        @total_size, @next_cursor, @locks = digests.page(**@pagination)
 
         erb(unique_template(:locks))
       end

--- a/spec/sidekiq_unique_jobs/changelog_spec.rb
+++ b/spec/sidekiq_unique_jobs/changelog_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
   let(:job_id) { SecureRandom.hex(12) }
 
   describe "#add" do
-    subject(:add) { entity.add(entry) }
+    subject(:add) { entity.add(**entry) }
 
     let(:entry) do
       {


### PR DESCRIPTION
In executing specs by Ruby 2.7.0-preview2, warnings below happens. I fixed only parts not related to other gems.

```
$ ruby --version
ruby 2.7.0preview2 (2019-10-22 master 02aadf1032) [x86_64-darwin17]

$ bundle exec rake rspec
...
Randomized with seed 49938
/Users/tnakata/workspace/sidekiq-unique-jobs/spec/sidekiq_unique_jobs/changelog_spec.rb:12: warning: The last argument is used as the keyword parameter
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/changelog.rb:24: warning: for `add' defined here
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/web.rb:29: warning: The last argument is used as the keyword parameter02
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/digests.rb:81: warning: for `page' defined here
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/web.rb:29: warning: The last argument is used as the keyword parameter02
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/digests.rb:81: warning: for `page' defined here
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/web.rb:29: warning: The last argument is used as the keyword parameter02
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/digests.rb:81: warning: for `page' defined here
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/web.rb:29: warning: The last argument is used as the keyword parameter
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/digests.rb:81: warning: for `page' defined here
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/unique_args.rb:130: warning: The last argument is used as the keyword parameter
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/exceptions.rb:63: warning: for `initialize' defined here
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/unique_args.rb:130: warning: The last argument is used as the keyword parameter
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/exceptions.rb:63: warning: for `initialize' defined here
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/unique_args.rb:130: warning: The last argument is used as the keyword parameter
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/exceptions.rb:63: warning: for `initialize' defined here
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/sidekiq_unique_jobs.rb:209: warning: The last argument is used as the keyword parameter
/Users/tnakata/workspace/sidekiq-unique-jobs/lib/sidekiq_unique_jobs/exceptions.rb:80: warning: for `initialize' defined here
 542/542 |====================================================== 100 =======================================================>| Time: 00:00:03
...