### PR TITLE
Allow redis namespace to work with deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ For sidekiq versions before 5.1 a `sidekiq_retries_exhausted` block is required 
 ```ruby
 class MyWorker
   sidekiq_retries_exhausted do |msg, _ex|
-    SidekiqUniqueJobs::Digests.del(digest: msg['unique_digest']) if msg['unique_digest']
+    SidekiqUniqueJobs::Digests.delete_by_digest(msg['unique_digest']) if msg['unique_digest']
   end
 end
 ```
@@ -387,7 +387,7 @@ Starting in v5.1, Sidekiq can also fire a global callback when a job dies:
 # this goes in your initializer
 Sidekiq.configure_server do |config|
   config.death_handlers << ->(job, _ex) do
-    SidekiqUniqueJobs::Digests.del(digest: job['unique_digest']) if job['unique_digest']
+    SidekiqUniqueJobs::Digests.delete_by_digest(job['unique_digest']) if job['unique_digest']
   end
 end
 ```

--- a/lib/sidekiq_unique_jobs/digests.rb
+++ b/lib/sidekiq_unique_jobs/digests.rb
@@ -55,6 +55,8 @@ module SidekiqUniqueJobs
     # @raise [ArgumentError] when both pattern and digest are nil
     # @return [Array<String>] with unique digests
     def del(digest: nil, pattern: nil, count: DEFAULT_COUNT)
+      warn("#{self}.#{__method__} has been deprecated and will be removed in a future version")
+
       return delete_by_pattern(pattern, count: count) if pattern
       return delete_by_digest(digest) if digest
 
@@ -87,8 +89,6 @@ module SidekiqUniqueJobs
       result
     end
 
-    private
-
     # Deletes unique digests by pattern
     #
     # @param [String] pattern a key pattern to match with
@@ -105,6 +105,8 @@ module SidekiqUniqueJobs
 
       result
     end
+
+    private
 
     def batch_delete(digests) # rubocop:disable Metrics/MethodLength
       redis do |conn|

--- a/lib/sidekiq_unique_jobs/digests.rb
+++ b/lib/sidekiq_unique_jobs/digests.rb
@@ -64,7 +64,7 @@ module SidekiqUniqueJobs
     # Deletes unique digest either by a digest or pattern
     #
     # @param [String] digest the full digest to delete
-    def delete_by_digest(digest)
+    def delete_by_digest(digest) # rubocop:disable Metrics/MethodLength
       result, elapsed = timed do
         Scripts.call(:delete_by_digest, nil, keys: [
                        UNIQUE_SET,

--- a/lib/sidekiq_unique_jobs/on_conflict/replace.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/replace.rb
@@ -35,7 +35,7 @@ module SidekiqUniqueJobs
 
       # Delete the keys belonging to the job
       def delete_lock
-        Scripts.call(:delete_by_digest, nil, keys: [UNIQUE_SET, unique_digest])
+        SidekiqUniqueJobs::Digests.delete_by_digest(unique_digest)
       end
     end
   end

--- a/lib/sidekiq_unique_jobs/web.rb
+++ b/lib/sidekiq_unique_jobs/web.rb
@@ -44,7 +44,7 @@ module SidekiqUniqueJobs
       end
 
       app.get "/unique_digests/:digest/delete" do
-        SidekiqUniqueJobs::Digests.del(digest: params[:digest])
+        SidekiqUniqueJobs::Digests.delete_by_digest(params[:digest])
         redirect_to :unique_digests
       end
     end

--- a/lib/sidekiq_unique_jobs/web.rb
+++ b/lib/sidekiq_unique_jobs/web.rb
@@ -32,7 +32,7 @@ module SidekiqUniqueJobs
       end
 
       app.get "/unique_digests/delete_all" do
-        SidekiqUniqueJobs::Digests.del(pattern: "*", count: SidekiqUniqueJobs::Digests.count)
+        SidekiqUniqueJobs::Digests.delete_by_pattern("*", count: SidekiqUniqueJobs::Digests.count)
         redirect_to :unique_digests
       end
 

--- a/rails_example/config/initializers/sidekiq.rb
+++ b/rails_example/config/initializers/sidekiq.rb
@@ -10,7 +10,8 @@ Sidekiq.configure_server do |config|
   config.error_handlers << Proc.new {|ex,ctx_hash| p ex, ctx_hash }
 
   config.death_handlers << ->(job, _ex) do
-    SidekiqUniqueJobs::Digests.del(digest: job['unique_digest']) if job['unique_digest']
+    digest = job.dig('unique_digest')
+    SidekiqUniqueJobs::Digests.delete_by_digest(digest) if digest
   end
 
   # accepts :expiration (optional)

--- a/redis/delete_by_digest.lua
+++ b/redis/delete_by_digest.lua
@@ -1,15 +1,14 @@
 -- redis.replicate_commands();
-local unique_keys   = KEYS[1]
-local unique_digest = KEYS[2]
-
-local exists_key        = unique_digest .. ':EXISTS'
-local grabbed_key       = unique_digest .. ':GRABBED'
-local available_key     = unique_digest .. ':AVAILABLE'
-local version_key       = unique_digest .. ':VERSION'
-local run_exists_key    = unique_digest .. ':RUN:EXISTS'
-local run_grabbed_key   = unique_digest .. ':RUN:GRABBED'
-local run_available_key = unique_digest .. ':RUN:AVAILABLE'
-local run_version_key   = unique_digest .. ':RUN:VERSION'
+local unique_keys       = KEYS[1]
+local unique_digest     = KEYS[2]
+local exists_key        = KEYS[3]
+local grabbed_key       = KEYS[4]
+local available_key     = KEYS[5]
+local version_key       = KEYS[6]
+local run_exists_key    = KEYS[7]
+local run_grabbed_key   = KEYS[8]
+local run_available_key = KEYS[9]
+local run_version_key   = KEYS[10]
 
 local count = redis.call('SREM', unique_keys, unique_digest)
 redis.call('DEL', exists_key)


### PR DESCRIPTION
Close #438 

Redis namespace complained about keys attempting to be deleted without being able to be namespaced properly. This PR fixes that issue