### PR TITLE
Fix errors_as_string on lock_config.rb

### DIFF
--- a/lib/sidekiq_unique_jobs/lock_config.rb
+++ b/lib/sidekiq_unique_jobs/lock_config.rb
@@ -75,7 +75,7 @@ module SidekiqUniqueJobs
     def errors_as_string
       @errors_as_string ||= begin
         error_msg = +"\t"
-        error_msg << lock_config.errors.map { |key, val| "#{key}: :#{val}" }.join("\n\t")
+        error_msg << errors.map { |key, val| "#{key}: :#{val}" }.join("\n\t")
         error_msg
       end
     end


### PR DESCRIPTION
Was getting the following error message when trying to validate options:

     Failure/Error: specify { expect(described_class).to have_valid_sidekiq_options }
     
     NameError:
       undefined local variable or method `lock_config' for #<SidekiqUniqueJobs::LockConfig:0x00007fdc90af1008>
       Did you mean?  lock_info

     # /Users/dpiret/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-unique-jobs-7.0.0.beta9/lib/sidekiq_unique_jobs/lock_config.rb:78:in `errors_as_string'
     # /Users/dpiret/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/sidekiq-unique-jobs-7.0.0.beta9/lib/sidekiq_unique_jobs/rspec/matchers/have_valid_sidekiq_options.rb:29:in `failure_message'
     # /Users/dpiret/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.9.0/lib/rspec/expectations/handler.rb:35:in `handle_failure'
     # /Users/dpiret/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.9.0/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # /Users/dpiret/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.9.0/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # /Users/dpiret/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.9.0/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # /Users/dpiret/.asdf/installs/ruby/2.6.3/lib/ruby/gems/2.6.0/gems/rspec-expectations-3.9.0/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./spec/workers/poller_worker_spec.rb:14:in `block (2 levels) in <top (required)>'