### PR TITLE
Rename remaining unique_* keys to lock_*

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ class MyWorker
   sidekiq_options lock: :until_executed, queue: :undefault
   def perform(args); end
 
-  def self.unique_args(args)
+  def self.lock_args(args)
     # the way you consider unique arguments
   end
 end

--- a/bin/bench
+++ b/bin/bench
@@ -31,7 +31,7 @@ def get_item(num)
     "args" => [num, num],
     "queue" => QUEUES.sample,
     "jid" => JOB_IDS[num],
-    "unique_digest" => DIGESTS[num] }
+    "lock_digest" => DIGESTS[num] }
 end
 
 Benchmark.ips do |ips|

--- a/lib/sidekiq_unique_jobs/constants.rb
+++ b/lib/sidekiq_unique_jobs/constants.rb
@@ -17,6 +17,8 @@ module SidekiqUniqueJobs
   LIMIT                 ||= "limit"
   LIVE_VERSION          ||= "uniquejobs:live"
   LOCK                  ||= "lock"
+  LOCK_ARGS             ||= "lock_args"
+  LOCK_DIGEST           ||= "lock_digest"
   LOCK_EXPIRATION       ||= "lock_expiration"
   LOCK_INFO             ||= "lock_info"
   LOCK_LIMIT            ||= "lock_limit"

--- a/lib/sidekiq_unique_jobs/exceptions.rb
+++ b/lib/sidekiq_unique_jobs/exceptions.rb
@@ -14,7 +14,7 @@ module SidekiqUniqueJobs
   # @author Mikael Henriksson <mikael@zoolutions.se>
   class Conflict < UniqueJobsError
     def initialize(item)
-      super("Item with the key: #{item[UNIQUE_DIGEST]} is already scheduled or processing")
+      super("Item with the key: #{item[LOCK_DIGEST]} is already scheduled or processing")
     end
   end
 
@@ -61,15 +61,17 @@ module SidekiqUniqueJobs
   # @author Mikael Henriksson <mikael@zoolutions.se>
   class InvalidUniqueArguments < UniqueJobsError
     def initialize(options)
-      given              = options[:given]
-      worker_class       = options[:worker_class]
-      unique_args_method = options[:unique_args_method]
-      uniq_args_meth     = worker_class.method(unique_args_method)
-      num_args           = uniq_args_meth.arity
-      # source_location = uniq_args_meth.source_location
+      given            = options[:given]
+      worker_class     = options[:worker_class]
+      lock_args_method = options[:lock_args_method]
+      lock_args_meth   = worker_class.method(lock_args_method)
+      num_args         = lock_args_meth.arity
+      source_location  = lock_args_meth.source_location
 
       super(
-        "#{worker_class}#unique_args takes #{num_args} arguments, received #{given.inspect}"
+        "#{worker_class}##{lock_args_method} takes #{num_args} arguments, received #{given.inspect}" \
+        "\n\n" \
+        "   #{source_location.join(':')}"
       )
     end
   end

--- a/lib/sidekiq_unique_jobs/job.rb
+++ b/lib/sidekiq_unique_jobs/job.rb
@@ -7,22 +7,20 @@ module SidekiqUniqueJobs
   module Job
     extend self
 
-    # Adds timeout, expiration, unique_args, unique_prefix and unique_digest to the sidekiq job hash
+    # Adds timeout, expiration, lock_args, lock_prefix and lock_digest to the sidekiq job hash
     # @return [Hash] the job hash
     def prepare(item)
       add_lock_timeout(item)
       add_lock_ttl(item)
       add_digest(item)
-
-      item
     end
 
-    # Adds unique_args, unique_prefix and unique_digest to the sidekiq job hash
+    # Adds lock_args, lock_prefix and lock_digest to the sidekiq job hash
     # @return [Hash] the job hash
     def add_digest(item)
-      add_unique_prefix(item)
-      add_unique_args(item)
-      add_unique_digest(item)
+      add_lock_prefix(item)
+      add_lock_args(item)
+      add_lock_digest(item)
 
       item
     end
@@ -37,16 +35,16 @@ module SidekiqUniqueJobs
       item[LOCK_TIMEOUT] = SidekiqUniqueJobs::LockTimeout.calculate(item)
     end
 
-    def add_unique_args(item)
-      item[UNIQUE_ARGS] = SidekiqUniqueJobs::LockArgs.call(item)
+    def add_lock_args(item)
+      item[LOCK_ARGS] = SidekiqUniqueJobs::LockArgs.call(item)
     end
 
-    def add_unique_digest(item)
-      item[UNIQUE_DIGEST] = SidekiqUniqueJobs::LockDigest.call(item)
+    def add_lock_digest(item)
+      item[LOCK_DIGEST] = SidekiqUniqueJobs::LockDigest.call(item)
     end
 
-    def add_unique_prefix(item)
-      item[UNIQUE_PREFIX] = SidekiqUniqueJobs.config.unique_prefix
+    def add_lock_prefix(item)
+      item[LOCK_PREFIX] = SidekiqUniqueJobs.config.unique_prefix
     end
   end
 end

--- a/lib/sidekiq_unique_jobs/lock/base_lock.rb
+++ b/lib/sidekiq_unique_jobs/lock/base_lock.rb
@@ -91,7 +91,7 @@ module SidekiqUniqueJobs
       private
 
       def prepare_item
-        return if item.key?(UNIQUE_DIGEST)
+        return if item.key?(LOCK_DIGEST)
 
         # The below should only be done to ease testing
         # in production this will be done by the middleware

--- a/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
@@ -21,7 +21,7 @@ module SidekiqUniqueJobs
             runtime_lock.execute { return yield }
           end
         else
-          log_warn "couldn't unlock digest: #{item[UNIQUE_DIGEST]} #{item[JID]}"
+          log_warn "couldn't unlock digest: #{item[LOCK_DIGEST]} #{item[JID]}"
         end
       end
 

--- a/lib/sidekiq_unique_jobs/lock/validator.rb
+++ b/lib/sidekiq_unique_jobs/lock/validator.rb
@@ -38,6 +38,7 @@ module SidekiqUniqueJobs
       def initialize(options)
         @options     = options.transform_keys(&:to_sym)
         @lock_config = LockConfig.new(options)
+        handle_deprecations
       end
 
       #
@@ -47,8 +48,6 @@ module SidekiqUniqueJobs
       # @return [LockConfig] the lock configuration with errors if any
       #
       def validate
-        handle_deprecations
-
         case lock_config.type
         when :while_executing
           validate_server

--- a/lib/sidekiq_unique_jobs/lock/validator.rb
+++ b/lib/sidekiq_unique_jobs/lock/validator.rb
@@ -11,7 +11,7 @@ module SidekiqUniqueJobs
       DEPRECATED_KEYS = {
         UNIQUE.to_sym => LOCK.to_sym,
         UNIQUE_ARGS.to_sym => LOCK_ARGS.to_sym,
-        UNIQUE_PREFIX.to_sym => LOCK_PREFIX.to_sym
+        UNIQUE_PREFIX.to_sym => LOCK_PREFIX.to_sym,
       }.freeze
 
       #

--- a/lib/sidekiq_unique_jobs/lock/validator.rb
+++ b/lib/sidekiq_unique_jobs/lock/validator.rb
@@ -8,6 +8,12 @@ module SidekiqUniqueJobs
     # @author Mikael Henriksson <mikael@zoolutions.se>
     #
     class Validator
+      DEPRECATED_KEYS = {
+        UNIQUE.to_sym => LOCK.to_sym,
+        UNIQUE_ARGS.to_sym => LOCK_ARGS.to_sym,
+        UNIQUE_PREFIX.to_sym => LOCK_PREFIX.to_sym
+      }.freeze
+
       #
       # Shorthand for `new(options).validate`
       #
@@ -30,6 +36,7 @@ module SidekiqUniqueJobs
       # @param [Hash] options the sidekiq_options for the worker being validated
       #
       def initialize(options)
+        @options     = options.transform_keys(&:to_sym)
         @lock_config = LockConfig.new(options)
       end
 
@@ -40,6 +47,8 @@ module SidekiqUniqueJobs
       # @return [LockConfig] the lock configuration with errors if any
       #
       def validate
+        handle_deprecations
+
         case lock_config.type
         when :while_executing
           validate_server
@@ -51,6 +60,14 @@ module SidekiqUniqueJobs
         end
 
         lock_config
+      end
+
+      def handle_deprecations
+        DEPRECATED_KEYS.each do |old, new|
+          next unless @options.key?(old)
+
+          lock_config.errors[old] = "is deprecated, use `#{new}: #{@options[old]}` instead."
+        end
       end
 
       #

--- a/lib/sidekiq_unique_jobs/lock/while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/while_executing.rb
@@ -51,7 +51,7 @@ module SidekiqUniqueJobs
       # This is safe as the base_lock always creates a new digest
       #   The append there for needs to be done every time
       def append_unique_key_suffix
-        item[UNIQUE_DIGEST] = item[UNIQUE_DIGEST] + RUN_SUFFIX
+        item[LOCK_DIGEST] = item[LOCK_DIGEST] + RUN_SUFFIX
       end
     end
   end

--- a/lib/sidekiq_unique_jobs/lock_args.rb
+++ b/lib/sidekiq_unique_jobs/lock_args.rb
@@ -107,8 +107,12 @@ module SidekiqUniqueJobs
 
     # The global worker options defined in Sidekiq directly
     def default_lock_args_method
-      Sidekiq.default_worker_options.stringify_keys[LOCK_ARGS] ||
-        Sidekiq.default_worker_options.stringify_keys[UNIQUE_ARGS]
+      default_worker_options[LOCK_ARGS] ||
+        default_worker_options[UNIQUE_ARGS]
+    end
+
+    def default_worker_options
+      @default_worker_options ||= Sidekiq.default_worker_options.stringify_keys
     end
   end
 end

--- a/lib/sidekiq_unique_jobs/lock_digest.rb
+++ b/lib/sidekiq_unique_jobs/lock_digest.rb
@@ -36,8 +36,8 @@ module SidekiqUniqueJobs
     def initialize(item)
       @item         = item
       @worker_class = item[CLASS]
-      @lock_args    = item[LOCK_ARGS] || item[UNIQUE_ARGS] # TODO: Deprecate UNIQUE_ARGS
-      @lock_prefix  = item[LOCK_PREFIX] || item[UNIQUE_PREFIX] # TODO: Deprecate UNIQUE_PREFIX
+      @lock_args    = item.slice(LOCK_ARGS, UNIQUE_ARGS).values.first # TODO: Deprecate UNIQUE_ARGS
+      @lock_prefix  = item.slice(LOCK_PREFIX, UNIQUE_PREFIX).values.first # TODO: Deprecate UNIQUE_PREFIX
     end
 
     # Memoized lock_digest

--- a/lib/sidekiq_unique_jobs/lock_digest.rb
+++ b/lib/sidekiq_unique_jobs/lock_digest.rb
@@ -17,7 +17,7 @@ module SidekiqUniqueJobs
     # @return [String] a unique digest for the given arguments
     #
     def self.call(item)
-      new(item).unique_digest
+      new(item).lock_digest
     end
 
     # The sidekiq job hash
@@ -26,37 +26,37 @@ module SidekiqUniqueJobs
     #
     # @!attribute [r] args
     #   @return [Array<Objet>] the arguments passed to `perform_async`
-    attr_reader :unique_args
+    attr_reader :lock_args
     #
     # @!attribute [r] args
     #   @return [String] the prefix for the unique key
-    attr_reader :unique_prefix
+    attr_reader :lock_prefix
 
     # @param [Hash] item a Sidekiq job hash
     def initialize(item)
-      @item          = item
-      @worker_class  = item[CLASS]
-      @unique_args   = item[UNIQUE_ARGS]
-      @unique_prefix = item[UNIQUE_PREFIX]
+      @item         = item
+      @worker_class = item[CLASS]
+      @lock_args    = item[LOCK_ARGS] || item[UNIQUE_ARGS] # TODO: Deprecate UNIQUE_ARGS
+      @lock_prefix  = item[LOCK_PREFIX] || item[UNIQUE_PREFIX] # TODO: Deprecate UNIQUE_PREFIX
     end
 
-    # Memoized unique_digest
+    # Memoized lock_digest
     # @return [String] a unique digest
-    def unique_digest
-      @unique_digest ||= create_digest
+    def lock_digest
+      @lock_digest ||= create_digest
     end
 
-    # Creates a namespaced unique digest based on the {#digestable_hash} and the {#unique_prefix}
+    # Creates a namespaced unique digest based on the {#digestable_hash} and the {#lock_prefix}
     # @return [String] a unique digest
     def create_digest
       digest = ::Digest::MD5.hexdigest(dump_json(digestable_hash))
-      "#{unique_prefix}:#{digest}"
+      "#{lock_prefix}:#{digest}"
     end
 
     # Filter a hash to use for digest
     # @return [Hash] to use for digest
     def digestable_hash
-      @item.slice(CLASS, QUEUE, UNIQUE_ARGS).tap do |hash|
+      @item.slice(CLASS, QUEUE, LOCK_ARGS).tap do |hash|
         hash.delete(QUEUE) if unique_across_queues?
         hash.delete(CLASS) if unique_across_workers?
       end

--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -57,7 +57,7 @@ module SidekiqUniqueJobs
     #
     def initialize(item, redis_pool = nil)
       @item        = item
-      @key         = Key.new(item[UNIQUE_DIGEST])
+      @key         = Key.new(item[LOCK_DIGEST] || item[UNIQUE_DIGEST]) # fallback until can be removed
       @job_id      = item[JID]
       @config      = LockConfig.new(item)
       @redis_pool  = redis_pool
@@ -341,7 +341,7 @@ module SidekiqUniqueJobs
         TIMEOUT => item[LOCK_TIMEOUT],
         TTL => item[LOCK_TTL],
         LOCK => config.type,
-        UNIQUE_ARGS => item[UNIQUE_ARGS],
+        LOCK_ARGS => item[LOCK_ARGS],
         TIME => now_f,
       )
     end

--- a/lib/sidekiq_unique_jobs/logging/middleware_context.rb
+++ b/lib/sidekiq_unique_jobs/logging/middleware_context.rb
@@ -30,7 +30,7 @@ module SidekiqUniqueJobs
       #
       def logging_context
         middleware = is_a?(SidekiqUniqueJobs::Middleware::Client) ? :client : :server
-        digest     = item[UNIQUE_DIGEST]
+        digest     = item[LOCK_DIGEST]
         lock_type  = item[LOCK]
 
         if logger_context_hash?

--- a/lib/sidekiq_unique_jobs/middleware.rb
+++ b/lib/sidekiq_unique_jobs/middleware.rb
@@ -80,7 +80,7 @@ module SidekiqUniqueJobs
       @redis_pool   = redis_pool
       return yield if unique_disabled?
 
-      SidekiqUniqueJobs::Job.prepare(item) unless item[UNIQUE_DIGEST]
+      SidekiqUniqueJobs::Job.prepare(item) unless item[LOCK_DIGEST]
 
       with_logging_context do
         super

--- a/lib/sidekiq_unique_jobs/on_conflict/log.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/log.rb
@@ -16,7 +16,7 @@ module SidekiqUniqueJobs
       #
       def call
         log_info(<<~MESSAGE.chomp)
-          Skipping job with id (#{item[JID]}) because unique_digest: (#{item[UNIQUE_DIGEST]}) already exists
+          Skipping job with id (#{item[JID]}) because lock_digest: (#{item[LOCK_DIGEST]}) already exists
         MESSAGE
       end
     end

--- a/lib/sidekiq_unique_jobs/on_conflict/replace.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/replace.rb
@@ -23,7 +23,7 @@ module SidekiqUniqueJobs
       def initialize(item, redis_pool = nil)
         super(item, redis_pool)
         @queue         = item[QUEUE]
-        @unique_digest = item[UNIQUE_DIGEST]
+        @unique_digest = item[LOCK_DIGEST]
       end
 
       #

--- a/lib/sidekiq_unique_jobs/on_conflict/reschedule.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/reschedule.rb
@@ -20,10 +20,10 @@ module SidekiqUniqueJobs
       #   This will mess up sidekiq stats because a new job is created
       def call
         if sidekiq_worker_class?
-          log_info("Rescheduling #{item[UNIQUE_DIGEST]}")
+          log_info("Rescheduling #{item[LOCK_DIGEST]}")
           worker_class&.perform_in(5, *item[ARGS])
         else
-          log_warn("Skip rescheduling of #{item[UNIQUE_DIGEST]} because #{worker_class} is not a Sidekiq::Worker")
+          log_warn("Skip rescheduling of #{item[LOCK_DIGEST]} because #{worker_class} is not a Sidekiq::Worker")
         end
       end
     end

--- a/lib/sidekiq_unique_jobs/web/helpers.rb
+++ b/lib/sidekiq_unique_jobs/web/helpers.rb
@@ -65,7 +65,7 @@ module SidekiqUniqueJobs
       #
       # @return [String] a string containing all non-truncated arguments
       #
-      def display_unique_args(args, truncate_after_chars = 2000)
+      def display_lock_args(args, truncate_after_chars = 2000)
         return "Invalid job payload, args is nil" if args.nil?
         return "Invalid job payload, args must be an Array, not #{args.class.name}" unless args.is_a?(Array)
 

--- a/lib/sidekiq_unique_jobs/web/views/lock.erb
+++ b/lib/sidekiq_unique_jobs/web/views/lock.erb
@@ -35,11 +35,11 @@
           <td><%= @lock.info["timeout"] %></td>
         </tr>
         <tr>
-          <th scope=row><%= t('Unique Args') %></td>
+          <th scope=row><%= t('Args') %></td>
           <td>
             <code class="code-wrap">
               <!-- We don't want to truncate any job arguments when viewing a single job's status page -->
-              <div class="args-extended"><%= display_unique_args(@lock.info["unique_args"], nil) %></div>
+              <div class="args-extended"><%= display_lock_args(@lock.info["lock_args"], nil) %></div>
             </code>
           </td>
         </tr>

--- a/myapp/app/lib/lock_simulator.rb
+++ b/myapp/app/lib/lock_simulator.rb
@@ -47,7 +47,7 @@ module LockSimulator
                        "timeout" => rand(20),
                        "ttl" => nil,
                        "lock" => SidekiqUniqueJobs.locks.keys.sample,
-                       "unique_args" => UNIQUE_ARGS.sample(2),
+                       "lock_args" => UNIQUE_ARGS.sample(2),
                        "time" => now_f,
                      ))
           end

--- a/myapp/config/initializers/sidekiq.rb
+++ b/myapp/config/initializers/sidekiq.rb
@@ -20,7 +20,7 @@ Sidekiq.configure_server do |config|
   config.error_handlers << ->(ex, ctx_hash) { p ex, ctx_hash }
 
   config.death_handlers << lambda do |job, _ex|
-    digest = job["unique_digest"]
+    digest = job["lock_digest"]
     SidekiqUniqueJobs::Digests.delete_by_digest(digest) if digest
   end
 

--- a/spec/performance/lock_digest_spec.rb
+++ b/spec/performance/lock_digest_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe SidekiqUniqueJobs::LockDigest, perf: true do
-  let(:unique_args)  { described_class.new(item) }
+  let(:lock_digest)  { described_class.new(item) }
   let(:worker_class) { UntilExecutedJob }
   let(:class_name)   { worker_class.to_s }
   let(:queue)        { "myqueue" }
@@ -14,20 +14,20 @@ RSpec.describe SidekiqUniqueJobs::LockDigest, perf: true do
     }
   end
 
-  describe "#unique_digest" do
-    subject(:unique_digest) { unique_args.unique_digest }
+  describe "#lock_digest" do
+    subject(:lock_digest) { lock_digest.lock_digest }
 
     it "performs in under 0.1 ms" do
-      expect { unique_digest }.to perform_under(0.1).ms
+      expect { lock_digest }.to perform_under(0.1).ms
     end
 
     context "when args are empty" do
-      let(:another_unique_args) { described_class.new(item) }
+      let(:another_lock_digest) { described_class.new(item) }
       let(:worker_class)        { WithoutArgumentJob }
       let(:args)                { [] }
 
       it "performs in under 0.1 ms" do
-        expect { unique_digest }.to perform_under(0.1).ms
+        expect { lock_digest }.to perform_under(0.1).ms
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe SidekiqUniqueJobs::LockDigest, perf: true do
       let(:args)         { [1, 2, "type" => "it"] }
 
       it "performs in under 0.1 ms" do
-        expect { unique_digest }.to perform_under(0.1).ms
+        expect { lock_digest }.to perform_under(0.1).ms
       end
     end
 
@@ -45,7 +45,7 @@ RSpec.describe SidekiqUniqueJobs::LockDigest, perf: true do
       let(:args)         { [1, 2, "type" => "it"] }
 
       it "performs in under 0.1 ms" do
-        expect { unique_digest }.to perform_under(0.1).ms
+        expect { lock_digest }.to perform_under(0.1).ms
       end
     end
   end

--- a/spec/performance/locksmith_spec.rb
+++ b/spec/performance/locksmith_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SidekiqUniqueJobs::Locksmith, perf: true do
   let(:item_one) do
     {
       "jid" => jid_one,
-      "unique_digest" => digest,
+      "lock_digest" => digest,
       "lock_ttl" => lock_ttl,
       "lock" => lock_type,
       "lock_timeout" => lock_timeout,

--- a/spec/sidekiq/api_spec.rb
+++ b/spec/sidekiq/api_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Sidekiq::Api" do
       "queue" => "testqueue",
       "args" => [foo: "bar"] }
   end
-  let(:unique_digest) { "uniquejobs:863b7cb639bd71c828459b97788b2ada" }
-  let(:key)           { SidekiqUniqueJobs::Key.new(unique_digest) }
+  let(:lock_digest) { "uniquejobs:577db3c4fc72230bf2c256faa708a083" }
+  let(:key)         { SidekiqUniqueJobs::Key.new(lock_digest) }
 
   describe Sidekiq::SortedEntry::UniqueExtension do
     it "deletes uniqueness lock on delete" do
@@ -37,9 +37,9 @@ RSpec.describe "Sidekiq::Api" do
               "queue" => "testqueue",
               "retry" => true,
               "lock" => "until_executed",
-              "unique_args" => [{ "foo" => "bar" }],
-              "unique_digest" => key.digest,
-              "unique_prefix" => "uniquejobs",
+              "lock_args" => [{ "foo" => "bar" }],
+              "lock_digest" => key.digest,
+              "lock_prefix" => "uniquejobs",
             ),
           )
         end

--- a/spec/sidekiq/retry_set_spec.rb
+++ b/spec/sidekiq/retry_set_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Sidekiq::RetrySet do
       "queue" => queue,
       "retry_at" => retry_at,
       "retry_count" => 1,
-      "unique_digest" => unique_digest,
+      "lock_digest" => unique_digest,
     }
   end
 

--- a/spec/sidekiq_unique_jobs/cli_spec.rb
+++ b/spec/sidekiq_unique_jobs/cli_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SidekiqUniqueJobs::Cli, ruby_ver: ">= 2.4" do
   let(:item) do
     {
       "jid" => jid,
-      "unique_digest" => digest,
+      "lock_digest" => digest,
     }
   end
   let(:jid)           { "abcdefab" }

--- a/spec/sidekiq_unique_jobs/configuration_spec.rb
+++ b/spec/sidekiq_unique_jobs/configuration_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SidekiqUniqueJobs do
     let(:ttl)       { nil }
     let(:item) do
       {
-        "unique_digest" => digest,
+        "lock_digest" => digest,
         "jid" => jid,
         "lock_expiration" => ttl,
         "lock" => lock_type,

--- a/spec/sidekiq_unique_jobs/digests_spec.rb
+++ b/spec/sidekiq_unique_jobs/digests_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe SidekiqUniqueJobs::Digests do
   let(:digests) { described_class.new }
   let(:expected_keys) do
     {
-      "uniquejobs:e739dadc23533773b920936336341d01" => kind_of(Float),
-      "uniquejobs:56c68cab5038eb57959538866377560d" => kind_of(Float),
-      "uniquejobs:8d9e83be14c033be4496295ec2740b91" => kind_of(Float),
-      "uniquejobs:23e8715233c2e8f7b578263fcb8ac657" => kind_of(Float),
-      "uniquejobs:6722965def15faf3c45cb9e66f994a49" => kind_of(Float),
-      "uniquejobs:5bdd20fbbdda2fc28d6461e0eb1f76ee" => kind_of(Float),
-      "uniquejobs:c658060a30b761bb12f2133cb7c3f294" => kind_of(Float),
-      "uniquejobs:b34294c4802ee2d61c9e3e8dd7f2bab4" => kind_of(Float),
-      "uniquejobs:06c3a5b63038c7b724b8603bb02ace99" => kind_of(Float),
-      "uniquejobs:62c11d32fd69c691802579682409a483" => kind_of(Float),
+      "uniquejobs:0781b1f587a9a8d08773f21ed752caed" => kind_of(Float),
+      "uniquejobs:09b3a42f77a75865bf27ac44e66bb4ef" => kind_of(Float),
+      "uniquejobs:1c4c0bf2a8a1006c7610e4ef1f965f34" => kind_of(Float),
+      "uniquejobs:236feda848cfbb1ae32d4d9af666349e" => kind_of(Float),
+      "uniquejobs:77d1e23f18943bc048b48a01b85af0b3" => kind_of(Float),
+      "uniquejobs:9fcaaf3e873f101a8d79e00e89bb3b36" => kind_of(Float),
+      "uniquejobs:a47040c19b3741eaf912a96cd8bee728" => kind_of(Float),
+      "uniquejobs:c85f45d715232cfff0505fb85ca92659" => kind_of(Float),
+      "uniquejobs:cb5be91a66b83435281c23fe489f22b5" => kind_of(Float),
+      "uniquejobs:e74bebbf569d620397688fded62c85d6" => kind_of(Float),
     }
   end
 
@@ -32,7 +32,7 @@ RSpec.describe SidekiqUniqueJobs::Digests do
   describe "#delete_by_digest" do
     subject(:delete_by_digest) { digests.delete_by_digest(digest) }
 
-    let(:digest) { "uniquejobs:62c11d32fd69c691802579682409a483" }
+    let(:digest) { "uniquejobs:e74bebbf569d620397688fded62c85d6" }
 
     before do
       allow(digests).to receive(:log_info)

--- a/spec/sidekiq_unique_jobs/job_spec.rb
+++ b/spec/sidekiq_unique_jobs/job_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe SidekiqUniqueJobs::Job do
           "args" => [1, 2],
           "lock_timeout" => MyUniqueJob.get_sidekiq_options["lock_timeout"].to_i,
           "lock_ttl" => MyUniqueJob.get_sidekiq_options["lock_ttl"],
-          "unique_args" => args,
-          "unique_digest" => "uniquejobs:77b7db49e1339ec4bda2addf1e74aae0",
-          "unique_prefix" => "uniquejobs",
+          "lock_args" => args,
+          "lock_digest" => "uniquejobs:149ef752a5776e0bd05929b8f0e33250",
+          "lock_prefix" => "uniquejobs",
         },
       )
     end

--- a/spec/sidekiq_unique_jobs/lock/until_expired_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/until_expired_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilExpired do
       process_one.lock
       process_one.execute {}
       expect(process_one).to be_locked
-      expect("uniquejobs:da6005926a8457526e998f0033901dfc").to have_ttl(1)
     end
   end
 

--- a/spec/sidekiq_unique_jobs/lock/validator_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/validator_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe SidekiqUniqueJobs::Lock::Validator do
       end
 
       it "writes a helpful message about the deprecated key" do
-         expect(validate.errors[:unique]).to eq('is deprecated, use `lock: until_executed` instead.')
-         expect(validate.errors[:unique_args]).to eq('is deprecated, use `lock_args: hokus` instead.')
-         expect(validate.errors[:unique_prefix]).to eq('is deprecated, use `lock_prefix: pokus` instead.')
+        expect(validate.errors[:unique]).to eq("is deprecated, use `lock: until_executed` instead.")
+        expect(validate.errors[:unique_args]).to eq("is deprecated, use `lock_args: hokus` instead.")
+        expect(validate.errors[:unique_prefix]).to eq("is deprecated, use `lock_prefix: pokus` instead.")
       end
     end
   end

--- a/spec/sidekiq_unique_jobs/lock/validator_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/validator_spec.rb
@@ -15,11 +15,23 @@ RSpec.describe SidekiqUniqueJobs::Lock::Validator do
 
   it { expect(true).to eq(true) }
 
-  # describe ".validate" do
-  #   subject(:validate) { described_class.validate({}) }
-  # end
+  describe "#validate" do
+    subject(:validate) { validator.validate }
 
-  # describe "#validate" do
-  #   subject(:validate) { validator.validate }
-  # end
+    context "with deprecated sidekiq_options" do
+      let(:options) do
+        {
+          "unique" => "until_executed",
+          "unique_args" => "hokus",
+          "unique_prefix" => "pokus",
+        }
+      end
+
+      it "writes a helpful message about the deprecated key" do
+         expect(validate.errors[:unique]).to eq('is deprecated, use `lock: until_executed` instead.')
+         expect(validate.errors[:unique_args]).to eq('is deprecated, use `lock_args: hokus` instead.')
+         expect(validate.errors[:unique_prefix]).to eq('is deprecated, use `lock_prefix: pokus` instead.')
+      end
+    end
+  end
 end

--- a/spec/sidekiq_unique_jobs/lock_args_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_args_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
             a_string_starting_with(
               "UniqueJobWithoutUniqueArgsParameter#unique_args takes 0 arguments," \
               " received [1]",
-            )
+            ),
           )
       end
 
@@ -122,7 +122,7 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
               a_string_starting_with(
                 "UniqueJobWithoutUniqueArgsParameter#unique_args takes 0 arguments," \
                 " received []",
-              )
+              ),
             )
         end
       end
@@ -138,8 +138,8 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
             SidekiqUniqueJobs::InvalidUniqueArguments,
             a_string_starting_with(
               'UniqueJobWithoutUniqueArgsParameter#unique_args takes 0 arguments,' \
-              ' received ["name", 2, {"whatever"=>nil, "type"=>"test"}]' \
-            )
+              ' received ["name", 2, {"whatever"=>nil, "type"=>"test"}]', \
+            ),
           )
       end
     end

--- a/spec/sidekiq_unique_jobs/lock_args_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_args_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe SidekiqUniqueJobs::LockArgs do
-  let(:unique_args)  { described_class.new(item) }
+  let(:lock_args)    { described_class.new(item) }
   let(:worker_class) { UntilExecutedJob }
   let(:class_name)   { worker_class.to_s }
   let(:queue)        { "myqueue" }
@@ -14,36 +14,36 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
     }
   end
 
-  describe "#unique_args_enabled?" do
-    subject(:unique_args_enabled?) { unique_args.unique_args_enabled? }
+  describe "#lock_args_enabled?" do
+    subject(:lock_args_enabled?) { lock_args.lock_args_enabled? }
 
     context "with default worker options", :with_sidekiq_options do
-      let(:sidekiq_options) { { unique: :until_executed, unique_args: ->(args) { args[1]["test"] } } }
+      let(:sidekiq_options) { { unique: :until_executed, lock_args: ->(args) { args[1]["test"] } } }
 
-      context "when `unique_args: :unique_args` in worker", :with_worker_options do
-        let(:worker_options) { { unique_args: :unique_args } }
+      context "when `lock_args: :lock_args` in worker", :with_worker_options do
+        let(:worker_options) { { lock_args: :lock_args } }
 
-        it { is_expected.to eq(:unique_args) }
+        it { is_expected.to eq(:lock_args) }
       end
 
-      context "when `unique_args: false` in worker", :with_worker_options do
-        let(:worker_options) { { unique_args: false } }
+      context "when `lock_args: false` in worker", :with_worker_options do
+        let(:worker_options) { { lock_args: false } }
 
         it { is_expected.to be_a(Proc) }
       end
     end
 
     context "when disabled in default_worker_options", :with_sidekiq_options do
-      let(:sidekiq_options) { { unique: false, unique_args: nil } }
+      let(:sidekiq_options) { { unique: false, lock_args: nil } }
 
-      context "when `unique_args: :unique_args` in worker", :with_worker_options do
-        let(:worker_options) { { unique_args: :unique_args } }
+      context "when `lock_args: :lock_args` in worker", :with_worker_options do
+        let(:worker_options) { { lock_args: :lock_args } }
 
-        it { is_expected.to eq(:unique_args) }
+        it { is_expected.to eq(:lock_args) }
       end
 
-      context "when `unique_args: false` in worker", :with_worker_options do
-        let(:worker_options) { { unique_args: false } }
+      context "when `lock_args: false` in worker", :with_worker_options do
+        let(:worker_options) { { lock_args: false } }
 
         it { is_expected.to eq(nil) }
       end
@@ -51,13 +51,13 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
   end
 
   describe "#filtered_args" do
-    subject(:filtered_args) { unique_args.filtered_args }
+    subject(:filtered_args) { lock_args.filtered_args }
 
     let(:args) { [1, "test" => "it"] }
 
-    context "when #unique_args_method is nil" do
+    context "when #lock_args_method is nil" do
       before do
-        allow(unique_args).to receive(:unique_args_method).and_return(nil)
+        allow(lock_args).to receive(:lock_args_method).and_return(nil)
       end
 
       it { is_expected.to eq(args) }
@@ -65,21 +65,21 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
   end
 
   describe "#filter_by_proc" do
-    subject(:filter_by_proc) { unique_args.filter_by_proc(args) }
+    subject(:filter_by_proc) { lock_args.filter_by_proc(args) }
 
     let(:args) { [1, "test" => "it"] }
 
-    context "when #unique_args_method is a proc" do
+    context "when #lock_args_method is a proc" do
       let(:filter) { ->(args) { args[1]["test"] } }
 
-      before { allow(unique_args).to receive(:unique_args_method).and_return(filter) }
+      before { allow(lock_args).to receive(:lock_args_method).and_return(filter) }
 
       it { is_expected.to eq("it") }
     end
 
     context "when configured globally" do
       it "uses global filter" do
-        Sidekiq.use_options(unique_args: ->(args) { args.first }) do
+        Sidekiq.use_options(lock_args: ->(args) { args.first }) do
           expect(filter_by_proc).to eq(1)
         end
       end
@@ -87,7 +87,7 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
   end
 
   describe "#filter_by_symbol" do
-    subject(:filter_by_symbol) { unique_args.filter_by_symbol(args) }
+    subject(:filter_by_symbol) { lock_args.filter_by_symbol(args) }
 
     context "when filter is a working symbol" do
       let(:worker_class)  { UniqueJobWithFilterMethod }
@@ -105,8 +105,10 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
         expect { filter_by_symbol }
           .to raise_error(
             SidekiqUniqueJobs::InvalidUniqueArguments,
-            "UniqueJobWithoutUniqueArgsParameter#unique_args takes 0 arguments," \
-            " received [1]",
+            a_string_starting_with(
+              "UniqueJobWithoutUniqueArgsParameter#unique_args takes 0 arguments," \
+              " received [1]",
+            )
           )
       end
 
@@ -117,14 +119,16 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
           expect { filter_by_symbol }
             .to raise_error(
               SidekiqUniqueJobs::InvalidUniqueArguments,
-              "UniqueJobWithoutUniqueArgsParameter#unique_args takes 0 arguments," \
-              " received []",
+              a_string_starting_with(
+                "UniqueJobWithoutUniqueArgsParameter#unique_args takes 0 arguments," \
+                " received []",
+              )
             )
         end
       end
     end
 
-    context "when workers unique_args method doesn't take parameters" do
+    context "when workers lock_args method doesn't take parameters" do
       let(:worker_class) { UniqueJobWithoutUniqueArgsParameter }
       let(:args)         { ["name", 2, "whatever" => nil, "type" => "test"] }
 
@@ -132,20 +136,22 @@ RSpec.describe SidekiqUniqueJobs::LockArgs do
         expect { filter_by_symbol }
           .to raise_error(
             SidekiqUniqueJobs::InvalidUniqueArguments,
-            'UniqueJobWithoutUniqueArgsParameter#unique_args takes 0 arguments,' \
-            ' received ["name", 2, {"whatever"=>nil, "type"=>"test"}]',
+            a_string_starting_with(
+              'UniqueJobWithoutUniqueArgsParameter#unique_args takes 0 arguments,' \
+              ' received ["name", 2, {"whatever"=>nil, "type"=>"test"}]' \
+            )
           )
       end
     end
 
-    context "when @worker_class does not respond_to unique_args_method" do
+    context "when @worker_class does not respond_to lock_args_method" do
       let(:worker_class) { UniqueJobWithNoUniqueArgsMethod }
       let(:args)         { ["name", 2, "whatever" => nil, "type" => "test"] }
 
       it { is_expected.to eq(args) }
     end
 
-    context "when workers unique_args method returns nil" do
+    context "when workers lock_args method returns nil" do
       let(:worker_class) { UniqueJobWithNilUniqueArgs }
       let(:args) { ["name", 2, "whatever" => nil, "type" => "test"] }
 

--- a/spec/sidekiq_unique_jobs/lock_digest_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_digest_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe SidekiqUniqueJobs::LockDigest do
     {
       "class" => class_name,
       "queue" => queue,
-      "unique_args" => args,
+      "lock_args" => args,
     }
   end
 
-  describe "#unique_digest" do
-    subject(:unique_digest) { digest.unique_digest }
+  describe "#lock_digest" do
+    subject(:lock_digest) { digest.lock_digest }
 
     context "when args are empty" do
       let(:digest_two)   { described_class.new(item) }
@@ -23,8 +23,8 @@ RSpec.describe SidekiqUniqueJobs::LockDigest do
       let(:args)         { [] }
 
       context "with the same unique args" do
-        it "equals to unique_digest for that item" do
-          expect(unique_digest).to eq(digest_two.unique_digest)
+        it "equals to lock_digest for that item" do
+          expect(lock_digest).to eq(digest_two.lock_digest)
         end
       end
     end
@@ -36,16 +36,16 @@ RSpec.describe SidekiqUniqueJobs::LockDigest do
         context "with the same unique args" do
           let(:another_item) { item }
 
-          it "equals to unique_digest for that item" do
-            expect(unique_digest).to eq(digest_two.unique_digest)
+          it "equals to lock_digest for that item" do
+            expect(lock_digest).to eq(digest_two.lock_digest)
           end
         end
 
         context "with different unique args" do
-          let(:another_item) { item.merge("unique_args" => [1, 3, "type" => "that"]) }
+          let(:another_item) { item.merge("lock_args" => [1, 3, "type" => "that"]) }
 
-          it "differs from unique_digest for that item" do
-            expect(unique_digest).not_to eq(digest_two.unique_digest)
+          it "differs from lock_digest for that item" do
+            expect(lock_digest).not_to eq(digest_two.lock_digest)
           end
         end
       end
@@ -69,18 +69,18 @@ RSpec.describe SidekiqUniqueJobs::LockDigest do
   describe "#digestable_hash" do
     subject(:digestable_hash) { digest.digestable_hash }
 
-    it { is_expected.to eq("class" => "UntilExecutedJob", "queue" => "myqueue", "unique_args" => [[1, 2]]) }
+    it { is_expected.to eq("class" => "UntilExecutedJob", "queue" => "myqueue", "lock_args" => [[1, 2]]) }
 
     context "when unique_across_queues", :with_worker_options do
       let(:worker_options) { { unique_across_queues: true } }
 
-      it { is_expected.to eq("class" => "UntilExecutedJob", "unique_args" => [[1, 2]]) }
+      it { is_expected.to eq("class" => "UntilExecutedJob", "lock_args" => [[1, 2]]) }
     end
 
     context "when unique_across_workers", :with_worker_options do
       let(:worker_options) { { unique_across_workers: true } }
 
-      it { is_expected.to eq("queue" => "myqueue", "unique_args" => [[1, 2]]) }
+      it { is_expected.to eq("queue" => "myqueue", "lock_args" => [[1, 2]]) }
     end
   end
 

--- a/spec/sidekiq_unique_jobs/lock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SidekiqUniqueJobs::Lock do
       timeout: 10,
       ttl: 2,
       lock: :until_executed,
-      unique_args: [1, 2],
+      lock_args: [1, 2],
       time: SidekiqUniqueJobs.now_f,
     }
   end

--- a/spec/sidekiq_unique_jobs/locksmith_spec.rb
+++ b/spec/sidekiq_unique_jobs/locksmith_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SidekiqUniqueJobs::Locksmith do
   let(:item_one) do
     {
       "jid" => jid_one,
-      "unique_digest" => digest,
+      "lock_digest" => digest,
       "lock_ttl" => lock_ttl,
       "lock" => lock_type,
       "lock_timeout" => lock_timeout,

--- a/spec/sidekiq_unique_jobs/lua/delete_job_by_digest_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/delete_job_by_digest_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "delete_job_by_digest.lua" do
         "jid" => job_id,
         "retry_count" => 2,
         "failed_at" => Time.now.to_f,
-        "unique_digest" => digest,
+        "lock_digest" => digest,
       }
     end
 

--- a/spec/sidekiq_unique_jobs/lua/reap_orphans_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/reap_orphans_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "reap_orphans.lua" do
   let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info) }
   let(:job_id)   { "job_id" }
   let(:item)     { raw_item }
-  let(:raw_item) { { "class" => MyUniqueJob, "args" => [1, 2], "jid" => job_id, "unique_digest" => digest } }
+  let(:raw_item) { { "class" => MyUniqueJob, "args" => [1, 2], "jid" => job_id, "lock_digest" => digest } }
   let(:lock_info) do
     {
       "job_id" => job_id,
@@ -30,7 +30,7 @@ RSpec.describe "reap_orphans.lua" do
       "time" => now_f,
       "timeout" => nil,
       "ttl" => nil,
-      "unique_args" => [1, 2],
+      "lock_args" => [1, 2],
       "worker" => "MyUniqueJob",
     }
   end

--- a/spec/sidekiq_unique_jobs/middleware/client_spec.rb
+++ b/spec/sidekiq_unique_jobs/middleware/client_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SidekiqUniqueJobs::Middleware::Client, redis_db: 1 do
       expect(schedule_count).to eq(1)
 
       expected = %w[
-        uniquejobs:6e47d668ad22db2a3ba0afd331514ce2
+        uniquejobs:26a33855311a0a653c5e0b4af1d1458d
       ]
 
       expect(keys).to include(*expected)
@@ -101,7 +101,7 @@ RSpec.describe SidekiqUniqueJobs::Middleware::Client, redis_db: 1 do
     context "when filter method is defined" do
       it "pushes no duplicate messages" do
         expect(CustomQueueJobWithFilterMethod).to respond_to(:args_filter)
-        expect(CustomQueueJobWithFilterMethod.get_sidekiq_options["unique_args"]).to eq :args_filter
+        expect(CustomQueueJobWithFilterMethod.get_sidekiq_options["lock_args"]).to eq :args_filter
 
         Array.new(10) do |i|
           push_item(

--- a/spec/sidekiq_unique_jobs/middleware/server_spec.rb
+++ b/spec/sidekiq_unique_jobs/middleware/server_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SidekiqUniqueJobs::Middleware::Server, redis_db: 9 do
         jid = UntilExecutedJob.perform_async
         item = Sidekiq::Queue.new(queue).find_job(jid).item
 
-        digest = "uniquejobs:7f28fc7bce5b2f7ea9895080e9b2d282"
+        digest = "uniquejobs:cf51f14f752c9ca8f3cfb0bbebad4abc"
         expect(get(digest)).to eq(jid)
         set(digest, "NOT_DELETED")
 

--- a/spec/sidekiq_unique_jobs/on_conflict/log_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/log_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe SidekiqUniqueJobs::OnConflict::Log do
-  let(:strategy)      { described_class.new(item) }
-  let(:unique_digest) { "uniquejobs:random-digest-value" }
-  let(:jid)           { "arandomjid" }
+  let(:strategy)    { described_class.new(item) }
+  let(:lock_digest) { "uniquejobs:random-digest-value" }
+  let(:jid)         { "arandomjid" }
   let(:item) do
-    { "unique_digest" => unique_digest, "jid" => jid }
+    { "lock_digest" => lock_digest, "jid" => jid }
   end
 
   describe "#call" do
@@ -13,7 +13,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Log do
       allow(strategy).to receive(:log_info)
       strategy.call
       expect(strategy).to have_received(:log_info).with(
-        "Skipping job with id (#{jid}) because unique_digest: (#{unique_digest}) already exists",
+        "Skipping job with id (#{jid}) because lock_digest: (#{lock_digest}) already exists",
       )
     end
   end

--- a/spec/sidekiq_unique_jobs/on_conflict/raise_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/raise_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Raise do
   let(:strategy)      { described_class.new(item) }
   let(:unique_digest) { "uniquejobs:random-digest-value" }
   let(:item) do
-    { "unique_digest" => unique_digest }
+    { "lock_digest" => unique_digest }
   end
 
   describe "#call" do

--- a/spec/sidekiq_unique_jobs/on_conflict/replace_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/replace_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
-  let(:strategy)      { described_class.new(item) }
-  let(:unique_digest) { "uniquejobs:56c68cab5038eb57959538866377560d" }
-  let(:block)         { -> { p "Hello" } }
-  let(:digest)        { digests.entries.first }
+  let(:strategy)    { described_class.new(item) }
+  let(:lock_digest) { "uniquejobs:0781b1f587a9a8d08773f21ed752caed" }
+  let(:block)       { -> { p "Hello" } }
+  let(:digest)      { digests.entries.first }
 
   let(:item) do
-    { "unique_digest" => unique_digest, "queue" => :customqueue }
+    { "lock_digest" => lock_digest, "queue" => :customqueue }
   end
 
   describe "#call" do
@@ -30,7 +30,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
           "jid" => jid,
           "retry_count" => 2,
           "failed_at" => Time.now.to_f,
-          "unique_digest" => unique_digest,
+          "lock_digest" => lock_digest,
         }
       end
 

--- a/spec/sidekiq_unique_jobs/on_conflict/reschedule_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/reschedule_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reschedule do
   let(:unique_digest) { "uniquejobs:random-digest-value" }
   let(:item) do
     { "class" => UniqueJobOnConflictReschedule,
-      "unique_digest" => unique_digest,
+      "lock_digest" => unique_digest,
       "args" => [1, 2] }
   end
 

--- a/spec/sidekiq_unique_jobs/on_conflict/strategy_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/strategy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Strategy do
   let(:strategy)      { described_class.new(item) }
   let(:unique_digest) { "uniquejobs:56c68cab5038eb57959538866377560d" }
   let(:item) do
-    { "unique_digest" => unique_digest, "queue" => :customqueue }
+    { "lock_digest" => unique_digest, "queue" => :customqueue }
   end
 
   describe "#replace?" do

--- a/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
   let(:job_id)   { "job_id" }
   let(:item)     { raw_item }
   let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info) }
-  let(:raw_item) { { "class" => MyUniqueJob, "args" => [], "jid" => job_id, "unique_digest" => digest } }
+  let(:raw_item) { { "class" => MyUniqueJob, "args" => [], "jid" => job_id, "lock_digest" => digest } }
   let(:lock_info) do
     {
       "job_id" => job_id,
@@ -15,7 +15,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
       "time" => now_f,
       "timeout" => nil,
       "ttl" => nil,
-      "unique_args" => [],
+      "lock_args" => [],
       "worker" => "MyUniqueJob",
     }
   end

--- a/spec/support/workers/custom_queue_job_with_filter_method.rb
+++ b/spec/support/workers/custom_queue_job_with_filter_method.rb
@@ -5,7 +5,7 @@
 require_relative "custom_queue_job"
 
 class CustomQueueJobWithFilterMethod < CustomQueueJob
-  sidekiq_options lock: :until_executed, unique_args: :args_filter
+  sidekiq_options lock: :until_executed, lock_args: :args_filter
 
   def self.args_filter(args)
     args.first

--- a/spec/support/workers/custom_queue_job_with_filter_proc.rb
+++ b/spec/support/workers/custom_queue_job_with_filter_proc.rb
@@ -8,7 +8,7 @@ class CustomQueueJobWithFilterProc < CustomQueueJob
   # slightly contrived example of munging args to the
   # worker and removing a random bit.
   sidekiq_options lock: :until_expired,
-                  unique_args: (lambda do |args|
+                  lock_args: (lambda do |args|
                     options = args.extract_options!
                     options.delete("random")
                     args + [options]

--- a/spec/support/workers/my_unique_job_with_filter_method.rb
+++ b/spec/support/workers/my_unique_job_with_filter_method.rb
@@ -8,7 +8,7 @@ class MyUniqueJobWithFilterMethod
                   lock: :until_executed,
                   queue: :customqueue,
                   retry: true,
-                  unique_args: :filtered_args
+                  lock_args: :filtered_args
 
   def perform(*)
     # NO-OP

--- a/spec/support/workers/my_unique_job_with_filter_proc.rb
+++ b/spec/support/workers/my_unique_job_with_filter_proc.rb
@@ -8,7 +8,7 @@ class MyUniqueJobWithFilterProc
                   lock: :until_executed,
                   queue: :customqueue,
                   retry: true,
-                  unique_args: (lambda do |args|
+                  lock_args: (lambda do |args|
                     options = args.extract_options!
                     [args.first, options["type"]]
                   end)

--- a/spec/support/workers/simple_worker.rb
+++ b/spec/support/workers/simple_worker.rb
@@ -6,7 +6,7 @@ class SimpleWorker
   include Sidekiq::Worker
   sidekiq_options lock: :until_executed,
                   queue: :default,
-                  unique_args: ->(args) { [args.first] }
+                  lock_args: ->(args) { [args.first] }
 
   def perform(args)
     sleep 5

--- a/spec/support/workers/unique_job_with_conditional_parameter.rb
+++ b/spec/support/workers/unique_job_with_conditional_parameter.rb
@@ -8,7 +8,7 @@ class UniqueJobWithoutUniqueArgsParameter
                   lock: :until_executed,
                   queue: :customqueue,
                   retry: true,
-                  unique_args: :unique_args
+                  lock_args: :unique_args
 
   def perform(conditional = nil)
     [conditional]

--- a/spec/support/workers/unique_job_with_filter_method.rb
+++ b/spec/support/workers/unique_job_with_filter_method.rb
@@ -8,7 +8,7 @@ class UniqueJobWithFilterMethod
                   lock: :while_executing,
                   queue: :customqueue,
                   retry: 1,
-                  unique_args: :filtered_args
+                  lock_args: :filtered_args
 
   def perform(*)
     # NO-OP

--- a/spec/support/workers/unique_job_with_nil_unique_args.rb
+++ b/spec/support/workers/unique_job_with_nil_unique_args.rb
@@ -8,7 +8,7 @@ class UniqueJobWithNilUniqueArgs
                   lock: :until_executed,
                   queue: :customqueue,
                   retry: true,
-                  unique_args: :unique_args
+                  lock_args: :unique_args
 
   def perform(args)
     [args]

--- a/spec/support/workers/unique_job_with_no_unique_args_method.rb
+++ b/spec/support/workers/unique_job_with_no_unique_args_method.rb
@@ -8,7 +8,7 @@ class UniqueJobWithNoUniqueArgsMethod
                   lock: :until_executed,
                   queue: :customqueue,
                   retry: true,
-                  unique_args: :filtered_args
+                  lock_args: :filtered_args
 
   def perform(one, two)
     [one, two]

--- a/spec/support/workers/unique_job_without_unique_args_parameter.rb
+++ b/spec/support/workers/unique_job_without_unique_args_parameter.rb
@@ -8,7 +8,7 @@ class UniqueJobWithoutUniqueArgsParameter
                   lock: :until_executed,
                   queue: :customqueue,
                   retry: true,
-                  unique_args: :unique_args
+                  lock_args: :unique_args
 
   def perform(optional = true)
     # NO-OP

--- a/spec/workers/custom_queue_job_with_filter_method_spec.rb
+++ b/spec/workers/custom_queue_job_with_filter_method_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CustomQueueJobWithFilterMethod do
         "queue" => :customqueue,
         "retry" => true,
         "lock" => :until_executed,
-        "unique_args" => :args_filter,
+        "lock_args" => :args_filter,
       }
     end
   end

--- a/spec/workers/custom_queue_job_with_filter_proc_spec.rb
+++ b/spec/workers/custom_queue_job_with_filter_proc_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CustomQueueJobWithFilterProc do
         "queue" => :customqueue,
         "retry" => true,
         "lock" => :until_expired,
-        "unique_args" => a_kind_of(Proc),
+        "lock_args" => a_kind_of(Proc),
       }
     end
   end

--- a/spec/workers/my_unique_job_with_filter_method_spec.rb
+++ b/spec/workers/my_unique_job_with_filter_method_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MyUniqueJobWithFilterMethod do
         "queue" => :customqueue,
         "retry" => true,
         "lock" => :until_executed,
-        "unique_args" => :filtered_args,
+        "lock_args" => :filtered_args,
       }
     end
   end

--- a/spec/workers/my_unique_job_with_filter_proc_spec.rb
+++ b/spec/workers/my_unique_job_with_filter_proc_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe MyUniqueJobWithFilterProc do
     let(:args) { ["one", "type" => "unique", "id" => 2] }
   end
 
-  describe "unique_args" do
-    subject(:unique_args) { described_class.get_sidekiq_options["unique_args"].call(args) }
+  describe "lock_args" do
+    subject(:lock_args) { described_class.get_sidekiq_options["lock_args"].call(args) }
 
     let(:args) { ["one", "type" => "unique", "id" => 2] }
 

--- a/spec/workers/simple_worker_spec.rb
+++ b/spec/workers/simple_worker_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe SimpleWorker do
     let(:args) { ["one", "type" => "unique", "id" => 2] }
   end
 
-  describe "unique_args" do
+  describe "lock_args" do
     subject do
-      described_class.get_sidekiq_options["unique_args"].call(args)
+      described_class.get_sidekiq_options["lock_args"].call(args)
     end
 
     let(:args) { ["unique", "type" => "unique", "id" => 2] }

--- a/spec/workers/unique_job_with_nil_unique_args_spec.rb
+++ b/spec/workers/unique_job_with_nil_unique_args_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UniqueJobWithNilUniqueArgs do
         "queue" => :customqueue,
         "retry" => true,
         "lock" => :until_executed,
-        "unique_args" => :unique_args,
+        "lock_args" => :unique_args,
       }
     end
   end

--- a/spec/workers/unique_job_with_no_unique_args_method_spec.rb
+++ b/spec/workers/unique_job_with_no_unique_args_method_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UniqueJobWithNoUniqueArgsMethod do
         "queue" => :customqueue,
         "retry" => true,
         "lock" => :until_executed,
-        "unique_args" => :filtered_args,
+        "lock_args" => :filtered_args,
       }
     end
   end

--- a/spec/workers/unique_job_without_unique_args_parameter_spec.rb
+++ b/spec/workers/unique_job_without_unique_args_parameter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UniqueJobWithoutUniqueArgsParameter do
         "queue" => :customqueue,
         "retry" => true,
         "lock" => :until_executed,
-        "unique_args" => :unique_args,
+        "lock_args" => :unique_args,
       }
     end
   end


### PR DESCRIPTION
The asymmetry drove me nuts so decided to deprecate existing keys with a fallback of course (for those upgrading).

## TODO
- [x] Add worker validation