### PR TITLE
Only configure RSpec when constant is defined

### DIFF
--- a/lib/sidekiq_unique_jobs/rspec/matchers.rb
+++ b/lib/sidekiq_unique_jobs/rspec/matchers.rb
@@ -17,8 +17,10 @@ module SidekiqUniqueJobs
   end
 end
 
-require_relative "matchers/have_valid_sidekiq_options"
+if defined?(RSpec)
+  require_relative "matchers/have_valid_sidekiq_options"
 
-RSpec.configure do |config|
-  config.include SidekiqUniqueJobs::RSpec::Matchers
+  RSpec.configure do |config|
+    config.include SidekiqUniqueJobs::RSpec::Matchers
+  end
 end


### PR DESCRIPTION
Close #466 

This should hopefully allow non-rspec users to validate their workers.