### PR TITLE
Use thread-safe digest creation mechanism

### DIFF
--- a/lib/sidekiq_unique_jobs/lock_digest.rb
+++ b/lib/sidekiq_unique_jobs/lock_digest.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'openssl'
+
 module SidekiqUniqueJobs
   # Handles uniqueness of sidekiq arguments
   #
@@ -49,7 +51,7 @@ module SidekiqUniqueJobs
     # Creates a namespaced unique digest based on the {#digestable_hash} and the {#lock_prefix}
     # @return [String] a unique digest
     def create_digest
-      digest = ::Digest::MD5.hexdigest(dump_json(digestable_hash))
+      digest = OpenSSL::Digest::MD5.hexdigest(dump_json(digestable_hash))
       "#{lock_prefix}:#{digest}"
     end
 


### PR DESCRIPTION
We've been getting the following error intermittently (like once a month):

`Digest::Base cannot be directly inherited in Ruby`

It turns out that the Digest::MD5 module used for creating the unique digest for the jobs is not thread-safe. Apparently many people have been having this issue for a long time (e.g. see https://github.com/aws/aws-sdk-ruby/issues/525). Using the OpenSSL module instead is reported to have solved the problem.