### PR TITLE
Use thread-safe digest creation mechanism

### DIFF
--- a/lib/sidekiq_unique_jobs/unique_args.rb
+++ b/lib/sidekiq_unique_jobs/unique_args.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "digest"
+require "openssl"
 require "sidekiq_unique_jobs/normalizer"
 
 module SidekiqUniqueJobs
@@ -47,7 +48,7 @@ module SidekiqUniqueJobs
     # Creates a namespaced unique digest based on the {#digestable_hash} and the {#unique_prefix}
     # @return [String] a unique digest
     def create_digest
-      digest = Digest::MD5.hexdigest(Sidekiq.dump_json(digestable_hash))
+      digest = OpenSSL::Digest::MD5.hexdigest(Sidekiq.dump_json(digestable_hash))
       "#{unique_prefix}:#{digest}"
     end
 


### PR DESCRIPTION
The Digest::MD5 module used for creating the unique digest for the jobs is not thread-safe. Apparently many people have been having this issue for a long time (e.g. see aws/aws-sdk-ruby#525). Using the OpenSSL module instead is reported to have solved the problem.

See #483 