### PR TITLE
CI: Use jruby-9.2.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
   fast_finish: true
 
   include:
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.11.1
       gemfile: gemfiles/sidekiq_6.0.gemfile
     - rvm: 2.6.5
       gemfile: gemfiles/sidekiq_6.0.gemfile


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.1**.

[JRuby 9.2.11.1 release blog post](https://www.jruby.org/2020/03/25/jruby-9-2-11-1.html)