### PR TITLE
[LockType] Allow overwriting default lock type at item level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .idea/
 .rspec_status
 .ruby-version
+.ruby-gemset
 /.byebug_history
 /.yardoc/
 /doc*/

--- a/lib/sidekiq_unique_jobs/options_with_fallback.rb
+++ b/lib/sidekiq_unique_jobs/options_with_fallback.rb
@@ -57,7 +57,7 @@ module SidekiqUniqueJobs
 
     # @return [Symbol]
     def lock_type
-      @lock_type ||= options[LOCK_KEY] || item[LOCK_KEY] || unique_type
+      @lock_type ||= item&.send(:[], LOCK_KEY) || options[LOCK_KEY] || unique_type
     end
 
     def unique_type

--- a/lib/sidekiq_unique_jobs/options_with_fallback.rb
+++ b/lib/sidekiq_unique_jobs/options_with_fallback.rb
@@ -57,7 +57,7 @@ module SidekiqUniqueJobs
 
     # @return [Symbol]
     def lock_type
-      @lock_type ||= item&.send(:[], LOCK_KEY) || options[LOCK_KEY] || unique_type
+      @lock_type ||= item[LOCK_KEY] || options[LOCK_KEY] || unique_type
     end
 
     def unique_type

--- a/spec/unit/sidekiq_unique_jobs/options_with_fallback_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/options_with_fallback_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe SidekiqUniqueJobs::OptionsWithFallback do
 
     it { is_expected.to eq(nil) }
 
-    context 'when options["unique"] is present' do
+    context 'when options["lock"] is present' do
       let(:options) { { "lock" => "while_executing" } }
       let(:item)    { { "lock" => "until_executed" } }
 
-      it { is_expected.to eq("while_executing") }
+      it { is_expected.to eq("until_executed") }
 
       context "when SidekiqUniqueJobs.config.enabled = false" do
         before { SidekiqUniqueJobs.config.enabled = false }
@@ -126,7 +126,7 @@ RSpec.describe SidekiqUniqueJobs::OptionsWithFallback do
       context 'when options["unique"] is present' do
         let(:options) { { "lock" => :while_executing } }
 
-        it { is_expected.to be_a(SidekiqUniqueJobs::Lock::WhileExecuting) }
+        it { is_expected.to be_a(SidekiqUniqueJobs::Lock::UntilExecuted) }
       end
     end
   end
@@ -134,18 +134,31 @@ RSpec.describe SidekiqUniqueJobs::OptionsWithFallback do
   describe "#lock_class" do
     subject(:lock_class) { options_with_fallback.lock_class }
 
-    context 'when item["unique"] is present' do
+    context 'when item["lock"] is present' do
+      
       let(:item) { { "lock" => :until_executed } }
 
       it { is_expected.to eq(SidekiqUniqueJobs::Lock::UntilExecuted) }
 
-      context 'when options["unique"] is present' do
+      context 'when options["lock"] is present' do
         let(:options) { { "lock" => :while_executing } }
 
-        it { is_expected.to eq(SidekiqUniqueJobs::Lock::WhileExecuting) }
+        it { is_expected.to eq(SidekiqUniqueJobs::Lock::UntilExecuted) }
       end
     end
 
+    context 'when options["lock"] is present' do
+    
+      let(:options) { { "lock" => :until_executed } }
+
+      it { is_expected.to eq(SidekiqUniqueJobs::Lock::UntilExecuted) }
+
+      context 'when item["lock"] is present' do
+        let(:item) { { "lock" => :while_executing } }
+
+        it { is_expected.to eq(SidekiqUniqueJobs::Lock::WhileExecuting) }
+      end
+    end    
     context "without matching class in LOCKS" do
       let(:item) { { "lock" => :until_unknown } }
 
@@ -160,16 +173,23 @@ RSpec.describe SidekiqUniqueJobs::OptionsWithFallback do
   describe "#lock_type" do
     subject { options_with_fallback.lock_type }
 
-    context 'when options["unique"] is while_executing' do
+    context 'when item["lock"] is while_executing' do
       let(:options) { { "lock" => "while_executing" } }
       let(:item)    { { "lock" => "until_executed" } }
 
-      it { is_expected.to eq("while_executing") }
+      it { is_expected.to eq("until_executed") }
     end
 
-    context 'when item["unique"] is until_executed' do
+    context 'when item["lock"] is until_executed' do
       let(:options) { {} }
       let(:item)    { { "lock" => "until_executed" } }
+
+      it { is_expected.to eq("until_executed") }
+    end
+
+    context 'when options["lock"] is until_executed' do
+      let(:options) { { "lock" => "until_executed" } }
+      let(:item)    { }
 
       it { is_expected.to eq("until_executed") }
     end

--- a/spec/unit/sidekiq_unique_jobs/options_with_fallback_spec.rb
+++ b/spec/unit/sidekiq_unique_jobs/options_with_fallback_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe SidekiqUniqueJobs::OptionsWithFallback do
 
     context 'when options["lock"] is until_executed' do
       let(:options) { { "lock" => "until_executed" } }
-      let(:item)    { }
+      let(:item)    { {} }
 
       it { is_expected.to eq("until_executed") }
     end


### PR DESCRIPTION
According to sidekiq documentation, any options from `sidekiq_options` can be overridden per call.
https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers

Based on that, I believe that the way things are implemented right now on `sidekiq-unique-jobs` is not correct, that's why I created this PR.

I spent a couple of hours today trying to understand why the code below was not working as expected. (couldn't find any documentation why you took the decision to implement things like this)

```
class TestWorker
  include Sidekiq::Worker
  sidekiq_options lock: :until_and_while_executing

  def perform
    puts "test"
  end
end

TestWorker.perform_async #=> should use the default lock `until_and_while_executing`
TestWorker.set(:lock => :while_executing).perform_async #=> should use the lock I am specifying `while_executing` but it was actually using `until_and_while_executing`
```

