### PR TITLE
Stringify on_conflict hash in Job prepare method

### DIFF
--- a/lib/sidekiq_unique_jobs/job.rb
+++ b/lib/sidekiq_unique_jobs/job.rb
@@ -10,6 +10,7 @@ module SidekiqUniqueJobs
     # Adds timeout, expiration, lock_args, lock_prefix and lock_digest to the sidekiq job hash
     # @return [Hash] the job hash
     def prepare(item)
+      stringify_on_conflict_hash(item)
       add_lock_timeout(item)
       add_lock_ttl(item)
       add_digest(item)
@@ -26,6 +27,13 @@ module SidekiqUniqueJobs
     end
 
     private
+
+    def stringify_on_conflict_hash(item)
+      on_conflict = item[ON_CONFLICT]
+      return unless on_conflict.is_a?(Hash)
+
+      item[ON_CONFLICT] = on_conflict.deep_stringify_keys
+    end
 
     def add_lock_ttl(item)
       item[LOCK_TTL] = SidekiqUniqueJobs::LockTTL.calculate(item)

--- a/spec/sidekiq_unique_jobs/job_spec.rb
+++ b/spec/sidekiq_unique_jobs/job_spec.rb
@@ -29,5 +29,22 @@ RSpec.describe SidekiqUniqueJobs::Job do
         },
       )
     end
+
+    context "when there is a hash in on_conflict" do
+      let(:worker_class) { UniqueJobOnConflictHash }
+
+      let(:job) { worker_class.get_sidekiq_options }
+
+      it "stringifies the on_conflict hash" do
+        expect(prepare).to match(
+          hash_including(
+            "on_conflict" => {
+              "client" => :log,
+              "server" => :reschedule,
+            },
+          ),
+        )
+      end
+    end
   end
 end

--- a/spec/sidekiq_unique_jobs/sidekiq_worker_methods_spec.rb
+++ b/spec/sidekiq_unique_jobs/sidekiq_worker_methods_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe SidekiqUniqueJobs::SidekiqWorkerMethods do
     let(:worker_class) { UniqueJobOnConflictHash }
 
     it do
-      expect(worker_options).to eq(
-        {
+      expect(worker_options).to match(
+        hash_including(
           "lock" => :until_and_while_executing,
           "on_conflict" => {
             "client" => :log,
@@ -77,7 +77,7 @@ RSpec.describe SidekiqUniqueJobs::SidekiqWorkerMethods do
           },
           "queue" => :customqueue,
           "retry" => true,
-        },
+        ),
       )
     end
   end


### PR DESCRIPTION
Unfortunately my PR yesterday did not resolve the issue. While we did correct `worker_options`, it turns out that in the client it doesn't follow that code path when there's a conflict. My apologies for missing the mark, I didn't test thoroughly enough.

I was able to determine the root cause of the issue. The `job_hash` is stringified by `Sidekiq.default_worker_options`, and it's just a shallow stringify. That means the `on_conflict` hash still has symbols for keys by the time it gets to `find_strategy`.

The approach I took to resolve is to stringify the hash in `Job#prepare`. I'm happy to change or tweak the approach on your advice.

Thanks for your time recently and the quick release! Hopefully this change fixes this issue for good.