### PR TITLE
Expire reaper when not checking in

### DIFF
--- a/spec/sidekiq_unique_jobs/web/helpers_spec.rb
+++ b/spec/sidekiq_unique_jobs/web/helpers_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe SidekiqUniqueJobs::Web::Helpers do
     let(:time)        { Time.now.to_f }
     let(:stamp)       { Time.now.getutc.iso8601 }
 
-    before { Timecop.freeze(frozen_time) }
-
-    after { Timecop.return }
+    around do |example|
+      Timecop.freeze(frozen_time, &example)
+    end
 
     it "returns relative time html" do
       expect(safe_relative_time).to eq(<<~HTML.chop)
@@ -26,9 +26,9 @@ RSpec.describe SidekiqUniqueJobs::Web::Helpers do
 
     let(:frozen_time) { Time.new(1982, 6, 8, 14, 15, 34) }
 
-    before { Timecop.freeze(frozen_time) }
-
-    after { Timecop.return }
+    around do |example|
+      Timecop.freeze(frozen_time, &example)
+    end
 
     context "when time is an Integer" do
       let(:time) { Time.now.to_i }


### PR DESCRIPTION
Close #490

By expiring the keys when the manager hasn't checked in for a while and allowing that for a while to drift a little to take into consideration some minor timing differences, it should now be possible even on SIGKILL for the reaping to continue by first deleting the existing key.