### PR TITLE
Don't bypass lock_args if arguments are empty

### DIFF
--- a/lib/sidekiq_unique_jobs/lock_args.rb
+++ b/lib/sidekiq_unique_jobs/lock_args.rb
@@ -63,7 +63,6 @@ module SidekiqUniqueJobs
     # @return [Array] args unfiltered when neither of the above
     def filtered_args
       return args if lock_args_disabled?
-      return args if args.empty?
 
       json_args = Normalizer.jsonify(args)
 


### PR DESCRIPTION
I'm using this gem in concert with [Apartment::Sidekiq](https://github.com/influitive/apartment-sidekiq) which enables enqueuing jobs in a multi-tenant application. As part of this, jobs can be enqueued without arguments but with the `apartment` key included in the item payload to specify which tenant the job should run for.

I would like to be able to use the current tenant in the `lock_args` array to allow the same job to run for different tenants but to prevent duplicate jobs for the same tenant from running. The `filtered_args` however currently short-circuits when the `args` array is empty making it impossible to specify lock arguments when the job itself does not accept arguments.