### PR TITLE
Backport #465 to 6.x series

### DIFF
--- a/sidekiq-unique-jobs.gemspec
+++ b/sidekiq-unique-jobs.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.5"
   spec.add_dependency "sidekiq", ">= 4.0", "< 7.0"
-  spec.add_dependency "thor", "~> 0"
+  spec.add_dependency "thor", ">= 0.20", "< 2.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rack-test", ">= 1.0", "< 2.0"


### PR DESCRIPTION
This change has been applied to 7.x, but that series is still in beta. It would be nice for the latest non-beta version of this gem not to be the only one keeping Thor constrained to 0.x versions. Thanks for considering cutting one more 6.x version.