### PR TITLE
Exit early when no results are returned from LRANGE given jobs might already processed

### DIFF
--- a/lib/sidekiq_unique_jobs/lua/shared/_delete_from_queue.lua
+++ b/lib/sidekiq_unique_jobs/lua/shared/_delete_from_queue.lua
@@ -6,6 +6,9 @@ local function delete_from_queue(queue, digest)
 
   while (index < total) do
     local items = redis.call("LRANGE", queue, index, index + per -1)
+    if #items == 0 then
+      break
+    end
     for _, item in pairs(items) do
       if string.find(item, digest) then
         redis.call("LREM", queue, 1, item)


### PR DESCRIPTION
Or a high load environment:
- The length is not guaranteed to be always as such
- Sidekiq can clear out some jobs
- We don't need to keep iterating if the jobs have already been cleared and there are no jobs
- This can be expensive operation to loop over unnecesarily

The other part of this is extra jobs added to the end of queue, but we can't safely predict that

(PS: My lua is weak, let me know better way if any :-) )