### PR TITLE
Fix RubyReaper active?

### DIFF
--- a/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
+++ b/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
@@ -135,6 +135,8 @@ module SidekiqUniqueJobs
               return true if load_json(job)[LOCK_DIGEST] == digest
             end
           end
+
+          false
         end
       end
 

--- a/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
@@ -121,9 +121,20 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
             end
           end
 
-          it "keeps the digest" do
-            expect { call }.not_to change { digests.count }.from(1)
-            expect(unique_keys).not_to match_array([])
+          context "that matches current digest" do
+            it "keeps the digest" do
+              expect { call }.not_to change { digests.count }.from(1)
+              expect(unique_keys).not_to match_array([])
+            end
+          end
+
+          context "that does not match current digest" do
+            let(:item) { { "class" => MyUniqueJob, "args" => [], "jid" => job_id, "lock_digest" => "uniquejobs:d2" } }
+
+            it "deletes the digest" do
+              expect { call }.to change { digests.count }.by(-1)
+              expect(unique_keys).to match_array([])
+            end
           end
         end
       end


### PR DESCRIPTION
Fixes https://github.com/mhenrixon/sidekiq-unique-jobs/issues/537

This PR should fix an issue where orphaned digests are not being considered orphaned if there are _any_ active jobs in Redis.

I've verified the broken behaviour by adding tests for when _other_ jobs are active that do not share the same unique digest - this test does not pass on `master`.

I'm not super familiar with the internals of Redis, but this should at the very least get the ball rolling in the right direction. Please point out anything that looks wrong.