### PR TITLE
Fix example url in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Before v7, the middleware was configured automatically. Since some people report
 
 *NOTE* if you want to use the reaper you also need to configure the server middleware.
 
-[A full and hopefully working example](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/master/myapp/config/sidekiq.rb#L12)
+[A full example](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/master/myapp/config/initializers/sidekiq.rb#L12)
 
 ```ruby
 Sidekiq.configure_server do |config|


### PR DESCRIPTION
The link to the full example in the `README` was pointing to a 404.

This PR corrects the url by linking to `config/initializers/sidekiq.rb` instead of `config/sidekiq.rb`.

I also took the liberty to remove the "and hopefully working" from the copy, to make the documentation
feel more assertive. I can revert that change if desired.