### PR TITLE
Improve compatibility with redis-namespace

### DIFF
--- a/lib/sidekiq_unique_jobs/sidekiq_unique_jobs.rb
+++ b/lib/sidekiq_unique_jobs/sidekiq_unique_jobs.rb
@@ -188,7 +188,7 @@ module SidekiqUniqueJobs
   # @return [String] a string like `5.0.2`
   #
   def fetch_redis_version
-    redis { |conn| conn.info("server")["redis_version"] }
+    Sidekiq.redis_info["redis_version"]
   end
 
   #


### PR DESCRIPTION
Close #578

Use not namespaced Redis connection to fetch redis_version.