### PR TITLE
Lock performance

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-          bundler: 2.2.15
+          bundler: 2.2.16
           bundler-cache: true
       - run: bin/bundle --jobs=$(nproc) --retry=$(nproc)
       - run: bin/rubocop -P
@@ -29,7 +29,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-          bundler: 2.2.15
+          bundler: 2.2.16
           bundler-cache: true
       - run: bin/bundle --jobs=$(nproc) --retry=$(nproc)
       - run: bin/reek .

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-          bundler: 2.2.15
+          bundler: 2.2.16
           bundler-cache: true
 
       - name: Install Code Climate reporter
@@ -56,7 +56,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: 2.2.15
+          bundler: 2.2.16
           bundler-cache: true
       - run: bin/appraisal install --jobs=$(nproc) --retry=$(nproc)
       - run: bin/appraisal rspec --require spec_helper --tag ~perf

--- a/.reek.yml
+++ b/.reek.yml
@@ -25,6 +25,7 @@ detectors:
     enabled: true
     exclude:
       - SidekiqUniqueJobs::DeleteOrphan
+      - SidekiqUniqueJobs::Logging
       - SidekiqUniqueJobs::Redis
   DuplicateMethodCall:
     exclude:
@@ -133,6 +134,7 @@ detectors:
       - SidekiqUniqueJobs::Locksmith#lock_async
       - SidekiqUniqueJobs::Locksmith#lock_sync
       - SidekiqUniqueJobs::LockTTL#calculate
+      - SidekiqUniqueJobs::Logging#build_message
       - SidekiqUniqueJobs::Logging::Middleware#logging_context
       - SidekiqUniqueJobs::Middleware#call
       - SidekiqUniqueJobs::Server#self.configure

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,10 @@ platforms :mri do
   gem "reek", ">= 5.3"
   gem "rspec-benchmark"
   gem "rubocop-mhenrixon"
-  gem "ruby-prof", require: false
+  gem "ruby-prof", ">= 0.17.0", require: false
   gem "simplecov-sublime", ">= 0.21.2", require: false
+  gem "stackprof", ">= 0.2.9", require: false
+  gem "test-prof"
   gem "travis"
 end
 

--- a/gemfiles/sidekiq_5.0.gemfile
+++ b/gemfiles/sidekiq_5.0.gemfile
@@ -30,8 +30,10 @@ platforms :mri do
   gem "reek", ">= 5.3"
   gem "rspec-benchmark"
   gem "rubocop-mhenrixon"
-  gem "ruby-prof", require: false
+  gem "ruby-prof", ">= 0.17.0", require: false
   gem "simplecov-sublime", ">= 0.21.2", require: false
+  gem "stackprof", ">= 0.2.9", require: false
+  gem "test-prof"
   gem "travis"
 end
 

--- a/gemfiles/sidekiq_5.1.gemfile
+++ b/gemfiles/sidekiq_5.1.gemfile
@@ -30,8 +30,10 @@ platforms :mri do
   gem "reek", ">= 5.3"
   gem "rspec-benchmark"
   gem "rubocop-mhenrixon"
-  gem "ruby-prof", require: false
+  gem "ruby-prof", ">= 0.17.0", require: false
   gem "simplecov-sublime", ">= 0.21.2", require: false
+  gem "stackprof", ">= 0.2.9", require: false
+  gem "test-prof"
   gem "travis"
 end
 

--- a/gemfiles/sidekiq_5.2.gemfile
+++ b/gemfiles/sidekiq_5.2.gemfile
@@ -30,8 +30,10 @@ platforms :mri do
   gem "reek", ">= 5.3"
   gem "rspec-benchmark"
   gem "rubocop-mhenrixon"
-  gem "ruby-prof", require: false
+  gem "ruby-prof", ">= 0.17.0", require: false
   gem "simplecov-sublime", ">= 0.21.2", require: false
+  gem "stackprof", ">= 0.2.9", require: false
+  gem "test-prof"
   gem "travis"
 end
 

--- a/gemfiles/sidekiq_6.0.gemfile
+++ b/gemfiles/sidekiq_6.0.gemfile
@@ -30,8 +30,10 @@ platforms :mri do
   gem "reek", ">= 5.3"
   gem "rspec-benchmark"
   gem "rubocop-mhenrixon"
-  gem "ruby-prof", require: false
+  gem "ruby-prof", ">= 0.17.0", require: false
   gem "simplecov-sublime", ">= 0.21.2", require: false
+  gem "stackprof", ">= 0.2.9", require: false
+  gem "test-prof"
   gem "travis"
 end
 

--- a/gemfiles/sidekiq_6.1.gemfile
+++ b/gemfiles/sidekiq_6.1.gemfile
@@ -30,8 +30,10 @@ platforms :mri do
   gem "reek", ">= 5.3"
   gem "rspec-benchmark"
   gem "rubocop-mhenrixon"
-  gem "ruby-prof", require: false
+  gem "ruby-prof", ">= 0.17.0", require: false
   gem "simplecov-sublime", ">= 0.21.2", require: false
+  gem "stackprof", ">= 0.2.9", require: false
+  gem "test-prof"
   gem "travis"
 end
 

--- a/gemfiles/sidekiq_develop.gemfile
+++ b/gemfiles/sidekiq_develop.gemfile
@@ -30,8 +30,10 @@ platforms :mri do
   gem "reek", ">= 5.3"
   gem "rspec-benchmark"
   gem "rubocop-mhenrixon"
-  gem "ruby-prof", require: false
+  gem "ruby-prof", ">= 0.17.0", require: false
   gem "simplecov-sublime", ">= 0.21.2", require: false
+  gem "stackprof", ">= 0.2.9", require: false
+  gem "test-prof"
   gem "travis"
 end
 

--- a/lib/sidekiq_unique_jobs/lock/base_lock.rb
+++ b/lib/sidekiq_unique_jobs/lock/base_lock.rb
@@ -124,7 +124,7 @@ module SidekiqUniqueJobs
       attr_reader :attempt
 
       def unlock_with_callback
-        return log_warn("might need to be unlocked manually") unless unlock
+        return log_warn("Might need to be unlocked manually", item) unless unlock
 
         callback_safely
         item[JID]
@@ -134,7 +134,7 @@ module SidekiqUniqueJobs
         callback&.call
         item[JID]
       rescue StandardError
-        log_warn("unlocked successfully but the #after_unlock callback failed!")
+        log_warn("Unlocked successfully but the #after_unlock callback failed!", item)
         raise
       end
 

--- a/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
@@ -21,7 +21,7 @@ module SidekiqUniqueJobs
             runtime_lock.execute { return yield }
           end
         else
-          log_warn "couldn't unlock digest: #{item[LOCK_DIGEST]} #{item[JID]}"
+          log_warn("Couldn't unlock digest: #{item[LOCK_DIGEST]}, jid: #{item[JID]}")
         end
       end
 

--- a/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
@@ -30,7 +30,7 @@ module SidekiqUniqueJobs
       def lock_on_failure
         yield
       rescue Exception # rubocop:disable Lint/RescueException
-        log_error("Runtime lock failed to execute job, restoring server lock")
+        log_error("Runtime lock failed to execute job, restoring server lock", item)
         lock
         raise
       end

--- a/lib/sidekiq_unique_jobs/lock_config.rb
+++ b/lib/sidekiq_unique_jobs/lock_config.rb
@@ -71,6 +71,10 @@ module SidekiqUniqueJobs
       @on_server_conflict = job_hash[ON_SERVER_CONFLICT]
     end
 
+    def lock_info?
+      lock_info
+    end
+
     #
     # Indicate if timeout was set
     #

--- a/spec/sidekiq_unique_jobs/logging_spec.rb
+++ b/spec/sidekiq_unique_jobs/logging_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe SidekiqUniqueJobs::Logging do
   let(:logger)  { SidekiqUniqueJobs.logger }
   let(:message) { "A log message" }
   let(:level)   { nil }
+  let(:worker)  { "JustAWorker" }
+  let(:queue)   { "testqueue" }
+  let(:args)    { [{ foo: "bar" }] }
+  let(:jid)     { "jobid" }
+  let(:digest)  { "digestable" }
+  let(:item) do
+    { "class" => worker,
+      "queue" => queue,
+      "args" => args,
+      "jid" => jid,
+      "lock_digest" => digest }
+  end
 
   before do
     allow(logger).to receive(level)
@@ -15,8 +27,11 @@ RSpec.describe SidekiqUniqueJobs::Logging do
     let(:level) { :debug }
 
     it "delegates to logger.debug" do
-      expect(log_debug(message)).to be_nil
-      expect(logger).to have_received(level).with(message)
+      expect(log_debug(message, item)).to be_nil
+      expect(logger).to have_received(level).with(
+        a_string_starting_with(message)
+          .and(ending_with("(queue=#{queue} class=#{worker} jid=#{jid} lock_digest=#{digest})")),
+      )
     end
   end
 
@@ -24,8 +39,11 @@ RSpec.describe SidekiqUniqueJobs::Logging do
     let(:level) { :info }
 
     it "delegates to logger.info" do
-      expect(log_info(message)).to be_nil
-      expect(logger).to have_received(level).with(message)
+      expect(log_info(message, item)).to be_nil
+      expect(logger).to have_received(level).with(
+        a_string_starting_with(message)
+          .and(ending_with("(queue=#{queue} class=#{worker} jid=#{jid} lock_digest=#{digest})")),
+      )
     end
   end
 
@@ -33,8 +51,11 @@ RSpec.describe SidekiqUniqueJobs::Logging do
     let(:level) { :warn }
 
     it "delegates to logger.warn" do
-      expect(log_warn(message)).to be_nil
-      expect(logger).to have_received(level).with(message)
+      expect(log_warn(message, item)).to be_nil
+      expect(logger).to have_received(level).with(
+        a_string_starting_with(message)
+          .and(ending_with("(queue=#{queue} class=#{worker} jid=#{jid} lock_digest=#{digest})")),
+      )
     end
   end
 
@@ -42,8 +63,11 @@ RSpec.describe SidekiqUniqueJobs::Logging do
     let(:level) { :error }
 
     it "delegates to logger.error" do
-      expect(log_error(message)).to be_nil
-      expect(logger).to have_received(level).with(message)
+      expect(log_error(message, item)).to be_nil
+      expect(logger).to have_received(level).with(
+        a_string_starting_with(message)
+          .and(ending_with("(queue=#{queue} class=#{worker} jid=#{jid} lock_digest=#{digest})")),
+      )
     end
   end
 
@@ -51,8 +75,11 @@ RSpec.describe SidekiqUniqueJobs::Logging do
     let(:level) { :fatal }
 
     it "delegates to logger.fatal" do
-      expect(log_fatal(message)).to be_nil
-      expect(logger).to have_received(level).with(message)
+      expect(log_fatal(message, item)).to be_nil
+      expect(logger).to have_received(level).with(
+        a_string_starting_with(message)
+          .and(ending_with("(queue=#{queue} class=#{worker} jid=#{jid} lock_digest=#{digest})")),
+      )
     end
   end
 


### PR DESCRIPTION
While doing some profiling information on the locks, it became apparent that most of the locks' time was spent waiting for concurrent ruby, which was a bug in the wait time for a value. 

**Before:**

<img width="814" alt="image" src="https://user-images.githubusercontent.com/106795/114673808-e3137580-9d06-11eb-8d8d-f87fbd3ba760.png">

**After:**

<img width="769" alt="image" src="https://user-images.githubusercontent.com/106795/114673885-f6264580-9d06-11eb-843f-196482928dd5.png">

Hopefully, this will improve performance a bit as there should be a lot less waiting time.