### PR TITLE
Add option to silence log output after a time out

### DIFF
--- a/lib/sidekiq_unique_jobs/config.rb
+++ b/lib/sidekiq_unique_jobs/config.rb
@@ -18,7 +18,8 @@ module SidekiqUniqueJobs
                                                    :reaper_timeout,
                                                    :lock_info,
                                                    :raise_on_config_error,
-                                                   :current_redis_version)
+                                                   :current_redis_version,
+                                                   :silence_lock_timeout)
 
   #
   # Shared class for dealing with gem configuration
@@ -118,6 +119,9 @@ module SidekiqUniqueJobs
     #
     # @return [0.0.0] default redis version is only to avoid NoMethodError on nil
     REDIS_VERSION         = "0.0.0"
+    #
+    # @return [false] silence timeout log output
+    SILENCE_LOCK_TIMEOUT  = false
 
     #
     # Returns a default configuration
@@ -158,6 +162,7 @@ module SidekiqUniqueJobs
     #   reaper_count: 1000,
     #   lock_info: false,
     #   raise_on_config_error: false,
+    #   silence_lock_timeout: false,
     #   }>
     #
     #
@@ -181,6 +186,7 @@ module SidekiqUniqueJobs
         USE_LOCK_INFO,
         RAISE_ON_CONFIG_ERROR,
         REDIS_VERSION,
+        SILENCE_LOCK_TIMEOUT,
       )
     end
 

--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -332,6 +332,8 @@ module SidekiqUniqueJobs
     end
 
     def warn_about_timeout
+      return if SidekiqUniqueJobs.config.silence_lock_timeout
+
       log_warn("Timed out after #{config.timeout}s while waiting for primed token (digest: #{key}, job_id: #{job_id})")
     end
 


### PR DESCRIPTION
When a lock cannot be acquired, the default behavior is to output a warning to inform the developer.

We ran into a case where we were pushing thousands of jobs to a queue, including many duplicates.
This caused a large number of log lines to be output, drowning our logs in noise:

```
WARN: Timed out after 0s while waiting for primed token (digest: uniquejobs:[...], job_id: [...])
```

This PR introduces a configuration option to allow for disabling this output. We the option defaults
to `false` so that the behavior out of the box is kept the same.

What do you think of this approach/feature?