### PR TITLE
Clarify the documentation related to lock_ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ SidekiqUniqueJobs.config.lock_ttl #=> nil
 
 Set a global lock_ttl to use for all jobs that don't otherwise specify a lock_ttl.
 
-Lock TTL decides how long to wait after the job has been successfully processed before making it possible to reuse that lock.
+Lock TTL decides how long to wait at most before considering a lock to be expired and making it possible to reuse that lock.
 
 ### enabled
 
@@ -336,7 +336,7 @@ sidekiq_options lock_prefix: "uniquejobs" # this is the default value
 
 ### lock_ttl
 
-Lock TTL decides how long to wait after the job has been successfully processed before making it possible to reuse that lock.
+Lock TTL decides how long to wait at most before considering a lock to be expired and making it possible to reuse that lock.
 
 Starting from `v7` the expiration will take place when the job is pushed to the queue.
 


### PR DESCRIPTION
To explain that a job with a lock_ttl will be unlocked either on
successful completion or when the lock_ttl expires.
The current documentation seems to imply that the lock gets unlocked
at job completion time + lock_ttl

Change made as a follow up to conversation in: https://github.com/mhenrixon/sidekiq-unique-jobs/issues/593