### PR TITLE
Allow locksmith delete to work with strings

### DIFF
--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -81,7 +81,7 @@ module SidekiqUniqueJobs
     # Deletes the lock regardless of if it has a pttl set
     #
     def delete!
-      call_script(:delete, key.to_a, [job_id, config.pttl, config.type, config.limit]).positive?
+      call_script(:delete, key.to_a, [job_id, config.pttl, config.type, config.limit]).to_i.positive?
     end
 
     #

--- a/spec/sidekiq_unique_jobs/locksmith_spec.rb
+++ b/spec/sidekiq_unique_jobs/locksmith_spec.rb
@@ -181,6 +181,14 @@ RSpec.describe SidekiqUniqueJobs::Locksmith do
       expect(locksmith_one).not_to be_locked
     end
 
+    it "allows deletion when call script returns a string" do
+      locksmith_one.lock
+      allow(locksmith_one).to receive(:call_script).and_return("120")
+      locksmith_two.delete!
+
+      expect(locksmith_one).not_to be_locked
+    end
+
     context "when lock_timeout is zero" do
       let(:lock_timeout) { 0 }
 


### PR DESCRIPTION
Hello 👋🏼 

Thank you for all the work you've put into the gem 🙇🏼 

We've noticed an error when we've update to version 7.x of the gem (currently were on 7.0.12), it looks like the `delete` script returns a string. To give a bit more context we're using Sidekiq 5.2.x and Redis 3.2.x those might have an influence over the reason why we're seeing a string been returned.

Anyway I think it would be beneficial if `.to_i` was called on the output of `call_script`. It could also be that we're doing something else wrong — I'm happy to share more config about our setup.

Let me know if this is something that can be added upstream or it's just an error with our configuration. 

---

Commit message

Previously if `call_script(:delete)` was returning a string an
error was raised since we couldn't call `.positive?` on it.

This change will ensure call script will always return a number.