### PR TITLE
Fix handling of lock timeout

### DIFF
--- a/lib/sidekiq_unique_jobs/lock_config.rb
+++ b/lib/sidekiq_unique_jobs/lock_config.rb
@@ -82,7 +82,7 @@ module SidekiqUniqueJobs
     # @return [true,fakse]
     #
     def wait_for_lock?
-      timeout && (timeout.zero? || timeout.positive?)
+      timeout.nil? || timeout.positive?
     end
 
     #

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby "2.7.2"
+ruby "~> 2.7"
 
 gem "bigdecimal"
 gem "coverband"
@@ -14,7 +14,7 @@ gem "puma"
 gem "rack-protection"
 gem "rails", ">= 6.0"
 gem "redis"
-gem "sidekiq", "6.1.2"
+gem "sidekiq", "~> 6.1"
 gem "sidekiq-unique-jobs", path: ".."
 gem "sinatra"
 gem "slim-rails"

--- a/myapp/app/workers/my_worker.rb
+++ b/myapp/app/workers/my_worker.rb
@@ -4,17 +4,17 @@ class MyWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: :my_queue_name,
-    # Locks when the client pushes the job to the queue.
-    # The queue will be unlocked when the server starts processing the job.
-    # The server then goes on to creating a runtime lock for the job to prevent
-    # simultaneous jobs from being executed. As soon as the server starts
-    # processing a job, the client can push the same job to the queue.
-    # https://github.com/mhenrixon/sidekiq-unique-jobs#until-and-while-executing
-    lock: :until_and_while_executing,
-    # search in logs SidekiqUniqueJobs keyword to find duplicates
-    log_duplicate_payload: true
+                  # Locks when the client pushes the job to the queue.
+                  # The queue will be unlocked when the server starts processing the job.
+                  # The server then goes on to creating a runtime lock for the job to prevent
+                  # simultaneous jobs from being executed. As soon as the server starts
+                  # processing a job, the client can push the same job to the queue.
+                  # https://github.com/mhenrixon/sidekiq-unique-jobs#until-and-while-executing
+                  lock: :until_and_while_executing,
+                  # search in logs SidekiqUniqueJobs keyword to find duplicates
+                  log_duplicate_payload: true
 
-  def perform(id)
-    logger.info(id)
+  def perform(my_id)
+    logger.info(my_id)
   end
 end

--- a/myapp/app/workers/my_worker.rb
+++ b/myapp/app/workers/my_worker.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class MyWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :my_queue_name,
+    # Locks when the client pushes the job to the queue.
+    # The queue will be unlocked when the server starts processing the job.
+    # The server then goes on to creating a runtime lock for the job to prevent
+    # simultaneous jobs from being executed. As soon as the server starts
+    # processing a job, the client can push the same job to the queue.
+    # https://github.com/mhenrixon/sidekiq-unique-jobs#until-and-while-executing
+    lock: :until_and_while_executing,
+    # search in logs SidekiqUniqueJobs keyword to find duplicates
+    log_duplicate_payload: true
+
+  def perform(id)
+    logger.info(id)
+  end
+end

--- a/spec/sidekiq_unique_jobs/lock_config_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_config_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SidekiqUniqueJobs::LockConfig do
     context "when timeout is nil" do
       let(:lock_timeout) { nil }
 
-      it { is_expected.to eq(nil) }
+      it { is_expected.to eq(true) }
     end
 
     context "when timeout is positive?" do
@@ -62,7 +62,7 @@ RSpec.describe SidekiqUniqueJobs::LockConfig do
     context "when timeout is zero?" do
       let(:lock_timeout) { 0 }
 
-      it { is_expected.to eq(true) }
+      it { is_expected.to eq(false) }
     end
   end
 


### PR DESCRIPTION
In #618 (#616) I accidentally created a breaking change. The default lock timeout of zero is not supposed to block but a nil value. I forgot about the inversion there.