### PR TITLE
Ensure `limit` and `timeout` are always numbers

### DIFF
--- a/lib/sidekiq_unique_jobs/lock_config.rb
+++ b/lib/sidekiq_unique_jobs/lock_config.rb
@@ -59,8 +59,8 @@ module SidekiqUniqueJobs
     def initialize(job_hash = {})
       @type        = job_hash[LOCK]&.to_sym
       @worker      = SidekiqUniqueJobs.safe_constantize(job_hash[CLASS])
-      @limit       = job_hash.fetch(LOCK_LIMIT, 1)
-      @timeout     = job_hash.fetch(LOCK_TIMEOUT, 0)
+      @limit       = job_hash.fetch(LOCK_LIMIT, 1)&.to_i
+      @timeout     = job_hash.fetch(LOCK_TIMEOUT, 0)&.to_i
       @ttl         = job_hash.fetch(LOCK_TTL) { job_hash.fetch(LOCK_EXPIRATION, nil) }.to_i
       @pttl        = ttl * 1_000
       @lock_info   = job_hash.fetch(LOCK_INFO) { SidekiqUniqueJobs.config.lock_info }
@@ -79,7 +79,7 @@ module SidekiqUniqueJobs
     # Indicate if timeout was set
     #
     #
-    # @return [true,fakse]
+    # @return [true,false]
     #
     def wait_for_lock?
       timeout.nil? || timeout.positive?

--- a/spec/sidekiq_unique_jobs/lock_config_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_config_spec.rb
@@ -44,6 +44,46 @@ RSpec.describe SidekiqUniqueJobs::LockConfig do
     end
   end
 
+  describe "#limit" do
+    context "when lock_limit is nil" do
+      let(:lock_limit) { nil }
+
+      its(:limit) { is_expected.to be_nil }
+    end
+
+    context "when lock_limit is a string" do
+      let(:lock_limit) { "1" }
+
+      its(:limit) { is_expected.to eq(1) }
+    end
+
+    context "when lock_limit is a number" do
+      let(:lock_limit) { 1 }
+
+      its(:limit) { is_expected.to eq(1) }
+    end
+  end
+
+  describe "#timeout" do
+    context "when lock_timeout is nil" do
+      let(:lock_timeout) { nil }
+
+      its(:timeout) { is_expected.to be_nil }
+    end
+
+    context "when lock_timeout is a string" do
+      let(:lock_timeout) { "1" }
+
+      its(:timeout) { is_expected.to eq(1) }
+    end
+
+    context "when lock_timeout is a number" do
+      let(:lock_timeout) { 1 }
+
+      its(:timeout) { is_expected.to eq(1) }
+    end
+  end
+
   describe "#wait_for_lock?" do
     subject(:wait_for_lock?) { lock_config.wait_for_lock? }
 
@@ -55,6 +95,12 @@ RSpec.describe SidekiqUniqueJobs::LockConfig do
 
     context "when timeout is positive?" do
       let(:lock_timeout) { 3 }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when timeout is a positive string?" do
+      let(:lock_timeout) { "3" }
 
       it { is_expected.to eq(true) }
     end


### PR DESCRIPTION
This should prevent errors where a string is passed
as the `lock_timeout` or `lock_limit` and `.positive?`
is called.