### PR TITLE
Disable resurrector by default

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-          bundler: 2.2.19
+          bundler: 2.2.24
           bundler-cache: true
       - run: bin/bundle --jobs=$(nproc) --retry=$(nproc)
       - run: bin/rubocop -P
@@ -29,7 +29,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-          bundler: 2.2.19
+          bundler: 2.2.24
           bundler-cache: true
       - run: bin/bundle --jobs=$(nproc) --retry=$(nproc)
       - run: bin/reek .

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -58,5 +58,5 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler: 2.2.24
           bundler-cache: true
-      - run: bin/appraisal install --jobs=$(nproc) --retry=$(nproc)
-      - run: bin/appraisal rspec --require spec_helper --tag ~perf
+      - run: bundle exec appraisal install --jobs=$(nproc) --retry=$(nproc)
+      - run: bundle exec appraisal rspec --require spec_helper --tag ~perf

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -58,5 +58,5 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler: 2.2.24
           bundler-cache: true
-      - run: bundle exec appraisal install --jobs=$(nproc) --retry=$(nproc)
-      - run: bundle exec appraisal rspec --require spec_helper --tag ~perf
+      - run: bin/appraisal install --jobs=$(nproc) --retry=$(nproc)
+      - run: bin/appraisal rspec --require spec_helper --tag ~perf

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-          bundler: 2.2.19
+          bundler: 2.2.24
           bundler-cache: true
 
       - name: Install Code Climate reporter
@@ -56,7 +56,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler: 2.2.19
+          bundler: 2.2.24
           bundler-cache: true
       - run: bin/appraisal install --jobs=$(nproc) --retry=$(nproc)
       - run: bin/appraisal rspec --require spec_helper --tag ~perf

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 gemspec
 
 LOCAL_GEMS = "Gemfile.local"
 
-gem "appraisal"
+gem "appraisal", github: "bibendi/appraisal", branch: "fix/ruby-3"
 gem "bundler"
 gem "gem-release"
 gem "github-markup"

--- a/lib/sidekiq_unique_jobs/config.rb
+++ b/lib/sidekiq_unique_jobs/config.rb
@@ -116,8 +116,8 @@ module SidekiqUniqueJobs
     REAPER_RESURRECTOR_INTERVAL = 3600
 
     #
-    # @return [true] enable reaper resurrector
-    REAPER_RESURRECTOR_ENABLED = true
+    # @return [false] enable reaper resurrector
+    REAPER_RESURRECTOR_ENABLED = false
 
     #
     # @return [false] while useful it also adds overhead so disable lock_info by default

--- a/spec/sidekiq_unique_jobs/orphans/reaper_resurrector_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/reaper_resurrector_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe SidekiqUniqueJobs::Orphans::ReaperResurrector do
     let(:frozen_time) { Time.new(1982, 6, 8, 14, 15, 34) }
 
     around do |example|
-      Timecop.freeze(frozen_time, &example)
+      Timecop.freeze(frozen_time) do
+        SidekiqUniqueJobs.use_config(reaper_resurrector_enabled: true, &example)
+      end
     end
 
     before do


### PR DESCRIPTION
It turns out some people have an issue with the number of redis connections so disable it until I can refactor the resurrector.