### PR TITLE
Pass lock timeout to primed_async

### DIFF
--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -102,7 +102,7 @@ module SidekiqUniqueJobs
       raise SidekiqUniqueJobs::InvalidArgument, "#execute needs a block" unless block
 
       redis(redis_pool) do |conn|
-        lock!(conn, method(:primed_async), &block)
+        lock!(conn, method(:primed_async), config.timeout, &block)
       end
     end
 


### PR DESCRIPTION
relates to https://github.com/mhenrixon/sidekiq-unique-jobs/issues/617

There is an issue where an integer `config.timeout` was being
respected in `pop_queued`, but the promise in `primed_async` was only
waiting the `config.ttl` plus the drift.

This means that high latency redis connections will return a `nil`
`primed_jid` and while_executing jobs will get dropped.

The proposed solution is to ensure that `config.timeout` gets passed in
as the `wait` argument to the bound `method(:primed_async)`, which
allows the `Concurrent::Promises` to timeout after the same duration
(plus drift) as the `brpoplpush` call.

The issue triage and approach is documented in:

  - https://github.com/mhenrixon/sidekiq-unique-jobs/issues/617#issuecomment-882826710
  - https://github.com/mhenrixon/sidekiq-unique-jobs/issues/617#issuecomment-883458295
  - https://github.com/mhenrixon/sidekiq-unique-jobs/issues/617#issuecomment-883488756

