### PR TITLE
Fix `on_conflict` strategy handling

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/base_lock.rb
+++ b/lib/sidekiq_unique_jobs/lock/base_lock.rb
@@ -104,7 +104,7 @@ module SidekiqUniqueJobs
       #
       # @param [Symbol] origin either `:client` or `:server`
       #
-      # @return [void]
+      # @return [String, nil]
       #
       def lock_failed(origin: :client)
         reflect(:lock_failed, item)

--- a/lib/sidekiq_unique_jobs/lock/base_lock.rb
+++ b/lib/sidekiq_unique_jobs/lock/base_lock.rb
@@ -109,7 +109,6 @@ module SidekiqUniqueJobs
       def lock_failed(origin: :client)
         reflect(:lock_failed, item)
         call_strategy(origin: origin)
-        nil
       end
 
       def call_strategy(origin:)

--- a/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
@@ -23,8 +23,8 @@ module SidekiqUniqueJobs
       # @yield to the caller when given a block
       #
       def lock(origin: :client)
-        return lock_failed(origin: origin) unless (token = locksmith.lock)
-        return yield token if block_given?
+        token = locksmith.lock || lock_failed(origin: origin)
+        return yield token if token && block_given?
 
         token
       end

--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -18,8 +18,8 @@ module SidekiqUniqueJobs
       # @yield to the caller when given a block
       #
       def lock
-        return lock_failed(origin: :client) unless (token = locksmith.lock)
-        return yield token if block_given?
+        token = locksmith.lock || lock_failed(origin: :client)
+        return yield token if token && block_given?
 
         token
       end

--- a/lib/sidekiq_unique_jobs/lock/until_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executing.rb
@@ -16,8 +16,8 @@ module SidekiqUniqueJobs
       # @return [String, nil] the locked jid when properly locked, else nil.
       #
       def lock
-        return lock_failed unless (job_id = locksmith.lock)
-        return yield job_id if block_given?
+        job_id = locksmith.lock || lock_failed
+        return yield job_id if job_id && block_given?
 
         job_id
       end

--- a/lib/sidekiq_unique_jobs/lock/until_expired.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_expired.rb
@@ -18,8 +18,8 @@ module SidekiqUniqueJobs
       # @yield to the caller when given a block
       #
       def lock
-        return lock_failed unless (job_id = locksmith.lock)
-        return yield job_id if block_given?
+        job_id = locksmith.lock || lock_failed
+        return yield job_id if job_id && block_given?
 
         job_id
       end

--- a/lib/sidekiq_unique_jobs/on_conflict/log.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/log.rb
@@ -12,12 +12,13 @@ module SidekiqUniqueJobs
       # Logs an informational message about that the job was not unique
       #
       #
-      # @return [void]
+      # @return [nil]
       #
       def call
         log_info(<<~MESSAGE.chomp)
           Skipping job with id (#{item[JID]}) because lock_digest: (#{item[LOCK_DIGEST]}) already exists
         MESSAGE
+        nil
       end
     end
   end

--- a/lib/sidekiq_unique_jobs/on_conflict/null_strategy.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/null_strategy.rb
@@ -7,6 +7,7 @@ module SidekiqUniqueJobs
     # @author Mikael Henriksson <mikael@mhenrixon.com>
     class NullStrategy < OnConflict::Strategy
       # Do nothing on conflict
+      #
       # @return [nil]
       def call
         # NOOP

--- a/lib/sidekiq_unique_jobs/on_conflict/reject.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/reject.rb
@@ -9,6 +9,8 @@ module SidekiqUniqueJobs
       include SidekiqUniqueJobs::Timing
 
       # Send jobs to dead queue
+      #
+      # @return [nil]
       def call
         log_info { "Adding dead #{item[CLASS]} job #{item[JID]}" }
 
@@ -17,6 +19,7 @@ module SidekiqUniqueJobs
         else
           push_to_deadset
         end
+        nil
       end
 
       #

--- a/lib/sidekiq_unique_jobs/on_conflict/replace.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/replace.rb
@@ -29,8 +29,7 @@ module SidekiqUniqueJobs
       #
       # Replace the old job in the queue
       #
-      #
-      # @return [void] <description>
+      # @return [String, nil]
       #
       # @yield to retry the lock after deleting the old one
       #

--- a/lib/sidekiq_unique_jobs/on_conflict/reschedule.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/reschedule.rb
@@ -19,6 +19,8 @@ module SidekiqUniqueJobs
 
       # Create a new job from the current one.
       #   This will mess up sidekiq stats because a new job is created
+      #
+      # @return [nil]
       def call
         if sidekiq_worker_class?
           if worker_class.perform_in(5, *item[ARGS])
@@ -29,6 +31,7 @@ module SidekiqUniqueJobs
         else
           reflect(:unknown_sidekiq_worker, item)
         end
+        nil
       end
     end
   end

--- a/spec/support/workers/until_and_while_executing_reject_job.rb
+++ b/spec/support/workers/until_and_while_executing_reject_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# :nocov:
+
+class UntilAndWhileExecutingRejectJob
+  include Sidekiq::Worker
+
+  sidekiq_options lock: :until_and_while_executing,
+                  queue: :working,
+                  on_conflict: {
+                    client: :reject,
+                    server: :reject,
+                  }
+
+  def self.lock_args(args)
+    [args[0]]
+  end
+
+  def perform(key); end
+end

--- a/spec/support/workers/until_and_while_executing_replace_job.rb
+++ b/spec/support/workers/until_and_while_executing_replace_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# :nocov:
+
+class UntilAndWhileExecutingReplaceJob
+  include Sidekiq::Worker
+
+  sidekiq_options lock: :until_and_while_executing,
+                  queue: :working,
+                  on_conflict: {
+                    client: :replace,
+                    server: :reschedule,
+                  }
+
+  def self.lock_args(args)
+    [args[0]]
+  end
+
+  def perform(key); end
+end

--- a/spec/workers/until_and_while_executing_reject_job_spec.rb
+++ b/spec/workers/until_and_while_executing_reject_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe UntilAndWhileExecutingRejectJob do
+  it_behaves_like "sidekiq with options" do
+    let(:options) do
+      {
+        "queue" => :working,
+        "retry" => true,
+        "lock" => :until_and_while_executing,
+        "on_conflict" => { client: :reject, server: :reject },
+      }
+    end
+  end
+
+  it "rejects the job successfully" do
+    Sidekiq::Testing.disable! do
+      set = Sidekiq::ScheduledSet.new
+
+      described_class.perform_at(Time.now + 30, 1)
+      expect(set.size).to eq(1)
+
+      expect(described_class.perform_at(Time.now + 30, 1)).to be_nil
+
+      set.each(&:delete)
+    end
+  end
+
+  it "rejects job successfully when using perform_in" do
+    Sidekiq::Testing.disable! do
+      set = Sidekiq::ScheduledSet.new
+
+      described_class.perform_in(30, 1)
+      expect(set.size).to eq(1)
+
+      expect(described_class.perform_in(30, 1)).to be_nil
+
+      set.each(&:delete)
+    end
+  end
+end

--- a/spec/workers/until_and_while_executing_replace_job_spec.rb
+++ b/spec/workers/until_and_while_executing_replace_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe UntilAndWhileExecutingReplaceJob do
+  it_behaves_like "sidekiq with options" do
+    let(:options) do
+      {
+        "queue" => :working,
+        "retry" => true,
+        "lock" => :until_and_while_executing,
+        "on_conflict" => { client: :replace, server: :reschedule },
+      }
+    end
+  end
+
+  it "replaces the previous job successfully" do
+    Sidekiq::Testing.disable! do
+      set = Sidekiq::ScheduledSet.new
+
+      described_class.perform_at(Time.now + 30, "unique", "first argument")
+      expect(set.size).to eq(1)
+      expect(set.first.item["args"]).to eq(["unique", "first argument"])
+
+      described_class.perform_at(Time.now + 30, "unique", "new argument")
+      expect(set.size).to eq(1)
+      expect(set.first.item["args"]).to eq(["unique", "new argument"])
+
+      set.each(&:delete)
+    end
+  end
+end

--- a/spec/workers/until_and_while_executing_replace_job_spec.rb
+++ b/spec/workers/until_and_while_executing_replace_job_spec.rb
@@ -27,4 +27,20 @@ RSpec.describe UntilAndWhileExecutingReplaceJob do
       set.each(&:delete)
     end
   end
+
+  it "replaces the previous job successfully when using perform_in" do
+    Sidekiq::Testing.disable! do
+      set = Sidekiq::ScheduledSet.new
+
+      described_class.perform_in(30, "unique", "first argument")
+      expect(set.size).to eq(1)
+      expect(set.first.item["args"]).to eq(["unique", "first argument"])
+
+      described_class.perform_in(30, "unique", "new argument")
+      expect(set.size).to eq(1)
+      expect(set.first.item["args"]).to eq(["unique", "new argument"])
+
+      set.each(&:delete)
+    end
+  end
 end

--- a/spec/workers/until_and_while_executing_replace_job_spec.rb
+++ b/spec/workers/until_and_while_executing_replace_job_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe UntilAndWhileExecutingReplaceJob do
       expect(set.size).to eq(1)
       expect(set.first.item["args"]).to eq(["unique", "first argument"])
 
-      described_class.perform_at(Time.now + 30, "unique", "new argument")
+      job_id = described_class.perform_at(Time.now + 30, "unique", "new argument")
+      expect(job_id).not_to be_nil
       expect(set.size).to eq(1)
       expect(set.first.item["args"]).to eq(["unique", "new argument"])
 
@@ -36,7 +37,8 @@ RSpec.describe UntilAndWhileExecutingReplaceJob do
       expect(set.size).to eq(1)
       expect(set.first.item["args"]).to eq(["unique", "first argument"])
 
-      described_class.perform_in(30, "unique", "new argument")
+      job_id = described_class.perform_in(30, "unique", "new argument")
+      expect(job_id).not_to be_nil
       expect(set.size).to eq(1)
       expect(set.first.item["args"]).to eq(["unique", "new argument"])
 


### PR DESCRIPTION
Hi! 👋 

we found a bug related to the `on_conflict` option. The change fixes it for our use case and hopefully as well for the rest of the uniqueness strategies.


This fixes the exception posted below when using `on_conflict: replace`
and potentially other bugs related to `on_conflict`. Before [this change][1]
`BasicLock.lock` always returned either the acquired lock or the return
value of `call_strategy`. Since `Middleware::Client#lock` now only
yields when `lock_instance.lock` yields we have to also `yield` inside
the lock instances when the lock was acquired via `lock_failed` (i.e. a
`on_conflict` strategy).

```
NoMethodError: undefined method `key?' for "f5d69f8fd2e1f3dde8cee02e":String
  from sidekiq/client.rb:197:in `atomic_push'
  from sidekiq/client.rb:190:in `block (2 levels) in raw_push'
  from redis.rb:2489:in `block in multi'
  from redis.rb:69:in `block in synchronize'
  from monitor.rb:202:in `synchronize'
  from monitor.rb:202:in `mon_synchronize'
  from redis.rb:69:in `synchronize'
  from redis.rb:2483:in `multi'
  from sidekiq/client.rb:189:in `block in raw_push'
  from connection_pool.rb:63:in `block (2 levels) in with'
  from connection_pool.rb:62:in `handle_interrupt'
  from connection_pool.rb:62:in `block in with'
  from connection_pool.rb:59:in `handle_interrupt'
  from connection_pool.rb:59:in `with'
  from sidekiq/client.rb:188:in `raw_push'
  from sidekiq/client.rb:74:in `push'
  from sidekiq/worker.rb:240:in `client_push'
  from sidekiq/worker.rb:215:in `perform_in'
```

 #590

[1]: https://github.com/mhenrixon/sidekiq-unique-jobs/commit/8c8d54c8b9dea363a7d8b8aeaceb2e82966b8503