### PR TITLE
OnConflict::Replace: yield when lock was achieved

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -18,7 +18,7 @@ detectors:
     exclude:
       - Sidekiq::JobSet::UniqueExtension#delete_by_value
       - Sidekiq::ScheduledSet::UniqueExtension#delete
-      - SidekiqUniqueJobs::Lock::BaseLock#call_strategy
+      - SidekiqUniqueJobs::Lock::BaseLock#strategy_for
       - SidekiqUniqueJobs::Orphans::Manager#start
       - SidekiqUniqueJobs::Orphans::RubyReaper#active?
       - SidekiqUniqueJobs::Redis::Hash#entries

--- a/lib/sidekiq_unique_jobs/lock/base_lock.rb
+++ b/lib/sidekiq_unique_jobs/lock/base_lock.rb
@@ -91,6 +91,13 @@ module SidekiqUniqueJobs
       #   @return [Integer] the current locking attempt
       attr_reader :attempt
 
+      #
+      # Eases testing by allowing the lock implementation to add the missing
+      # keys to the job hash.
+      #
+      #
+      # @return [void] the return value should be irrelevant
+      #
       def prepare_item
         return if item.key?(LOCK_DIGEST)
 
@@ -99,6 +106,16 @@ module SidekiqUniqueJobs
         SidekiqUniqueJobs::Job.prepare(item)
       end
 
+      #
+      # Call whatever strategry that has been configured
+      #
+      # @param [Symbol] origin: the origin `:client` or `:server`
+      #
+      # @return [void] the return value is irrelevant
+      #
+      # @yieldparam [void] if a new job id was set and a block is given
+      # @yieldreturn [void] the yield is irrelevant, it only provides a mechanism in
+      #   one specific situation to yield back to the middleware.
       def call_strategy(origin:)
         new_job_id = nil
         strategy   = strategy_for(origin)

--- a/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_and_while_executing.rb
@@ -22,9 +22,15 @@ module SidekiqUniqueJobs
       #
       # @yield to the caller when given a block
       #
-      def lock(origin: :client)
-        return lock_failed(origin: origin) unless (token = locksmith.lock)
-        return yield token if block_given?
+      def lock(origin: :client, &block)
+        unless (token = locksmith.lock)
+          reflect(:lock_failed, item)
+          call_strategy(origin: origin, &block)
+
+          return
+        end
+
+        yield if block
 
         token
       end

--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -17,9 +17,15 @@ module SidekiqUniqueJobs
       #
       # @yield to the caller when given a block
       #
-      def lock
-        return lock_failed(origin: :client) unless (token = locksmith.lock)
-        return yield token if block_given?
+      def lock(&block)
+        unless (token = locksmith.lock)
+          reflect(:lock_failed, item)
+          call_strategy(origin: :client, &block)
+
+          return
+        end
+
+        yield if block
 
         token
       end

--- a/lib/sidekiq_unique_jobs/lock/until_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executing.rb
@@ -15,11 +15,17 @@ module SidekiqUniqueJobs
       #
       # @return [String, nil] the locked jid when properly locked, else nil.
       #
-      def lock
-        return lock_failed unless (job_id = locksmith.lock)
-        return yield job_id if block_given?
+      def lock(&block)
+        unless (token = locksmith.lock)
+          reflect(:lock_failed, item)
+          call_strategy(origin: :client, &block)
 
-        job_id
+          return
+        end
+
+        yield if block
+
+        token
       end
 
       # Executes in the Sidekiq server process

--- a/lib/sidekiq_unique_jobs/lock/while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/while_executing.rb
@@ -40,7 +40,7 @@ module SidekiqUniqueJobs
       # @yield to the worker class perform method
       def execute
         with_logging_context do
-          call_strategy(origin: :server) unless locksmith.execute do
+          return call_strategy(origin: :server) unless locksmith.execute do
             yield
             callback_safely if locksmith.unlock
           ensure

--- a/lib/sidekiq_unique_jobs/middleware/client.rb
+++ b/lib/sidekiq_unique_jobs/middleware/client.rb
@@ -30,7 +30,7 @@ module SidekiqUniqueJobs
       private
 
       def lock
-        lock_instance.lock do |_locked_jid|
+        lock_instance.lock do
           reflect(:locked, item)
           return yield
         end

--- a/lib/sidekiq_unique_jobs/on_conflict/replace.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/replace.rb
@@ -43,6 +43,8 @@ module SidekiqUniqueJobs
         end
 
         block&.call
+
+        nil # Ensure we always return nil
       end
 
       #

--- a/lib/sidekiq_unique_jobs/on_conflict/replace.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/replace.rb
@@ -43,8 +43,6 @@ module SidekiqUniqueJobs
         end
 
         block&.call
-
-        nil # Ensure we always return nil
       end
 
       #

--- a/spec/sidekiq_unique_jobs/lock/base_lock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/base_lock_spec.rb
@@ -24,42 +24,6 @@ RSpec.describe SidekiqUniqueJobs::Lock::BaseLock do
     end
   end
 
-  describe "#replace?" do
-    subject(:replace?) { lock.send(:replace?, origin) }
-
-    let(:origin) { nil }
-
-    shared_examples "valid replace?" do
-      context "when strategy is not :replace" do
-        let(:strategy) { :log }
-
-        it { is_expected.to eq(false) }
-      end
-
-      context "when attempt is less than 2" do
-        it { is_expected.to eq(true) }
-      end
-
-      context "when attempt is equal to 2" do
-        before { lock.instance_variable_set(:@attempt, 2) }
-
-        it { is_expected.to eq(false) }
-      end
-    end
-
-    context "when origin is :client" do
-      let(:origin) { :client }
-
-      it_behaves_like "valid replace?"
-    end
-
-    context "when origin is :server" do
-      let(:origin) { :server }
-
-      it_behaves_like "valid replace?"
-    end
-  end
-
   describe "#callback_safely" do
     subject(:callback_safely) { lock.send(:callback_safely) }
 

--- a/spec/sidekiq_unique_jobs/lock/base_lock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/base_lock_spec.rb
@@ -25,22 +25,38 @@ RSpec.describe SidekiqUniqueJobs::Lock::BaseLock do
   end
 
   describe "#replace?" do
-    subject(:replace?) { lock.send(:replace?) }
+    subject(:replace?) { lock.send(:replace?, origin) }
 
-    context "when strategy is not :replace" do
-      let(:strategy) { :log }
+    let(:origin) { nil }
 
-      it { is_expected.to eq(false) }
+    shared_examples "valid replace?" do
+      context "when strategy is not :replace" do
+        let(:strategy) { :log }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "when attempt is less than 2" do
+        it { is_expected.to eq(true) }
+      end
+
+      context "when attempt is equal to 2" do
+        before { lock.instance_variable_set(:@attempt, 2) }
+
+        it { is_expected.to eq(false) }
+      end
     end
 
-    context "when attempt is less than 2" do
-      it { is_expected.to eq(true) }
+    context "when origin is :client" do
+      let(:origin) { :client }
+
+      it_behaves_like "valid replace?"
     end
 
-    context "when attempt is equal to 2" do
-      before { lock.instance_variable_set(:@attempt, 2) }
+    context "when origin is :server" do
+      let(:origin) { :server }
 
-      it { is_expected.to eq(false) }
+      it_behaves_like "valid replace?"
     end
   end
 

--- a/spec/sidekiq_unique_jobs/on_conflict/replace_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/replace_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
       end
 
       it "logs important information" do
-        call
+        expect(call).to eq(nil)
 
         expect(strategy).to have_received(:log_info).with("Deleted job: #{jid}")
         expect(strategy).to have_received(:log_info).with("Deleted `9` keys for #{lock_digest}")
@@ -56,7 +56,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
       end
 
       it "logs important information" do
-        call
+        expect(call).to eq(nil)
 
         expect(strategy).to have_received(:log_info).with("Deleted job: #{jid}")
         expect(strategy).not_to have_received(:log_info).with("Deleted `` keys for #{lock_digest}")
@@ -74,7 +74,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
       end
 
       it "does not call block" do
-        call
+        expect(call).to eq(nil)
         expect(block).not_to have_received(:call)
       end
     end
@@ -107,6 +107,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
 
       it "removes the job from the scheduled set" do
         expect { call }.to change { schedule_count }.from(1).to(0)
+        expect(call).to eq(nil)
         expect(block).to have_received(:call)
       end
     end
@@ -116,7 +117,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
 
       it "removes the job from the queue" do
         expect { call }.to change { queue_count(:customqueue) }.from(1).to(0)
-
+        expect(call).to eq(nil)
         expect(block).to have_received(:call)
       end
     end

--- a/spec/support/workers/until_and_while_executing_reject_job.rb
+++ b/spec/support/workers/until_and_while_executing_reject_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# :nocov:
+
+class UntilAndWhileExecutingRejectJob
+  include Sidekiq::Worker
+
+  sidekiq_options lock: :until_and_while_executing,
+                  queue: :working,
+                  on_conflict: {
+                    client: :reject,
+                    server: :reject,
+                  }
+
+  def self.lock_args(args)
+    [args[0]]
+  end
+
+  def perform(key); end
+end

--- a/spec/support/workers/until_and_while_executing_replace_job.rb
+++ b/spec/support/workers/until_and_while_executing_replace_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# :nocov:
+
+class UntilAndWhileExecutingReplaceJob
+  include Sidekiq::Worker
+
+  sidekiq_options lock: :until_and_while_executing,
+                  queue: :working,
+                  on_conflict: {
+                    client: :replace,
+                    server: :reschedule,
+                  }
+
+  def self.lock_args(args)
+    [args[0]]
+  end
+
+  def perform(key); end
+end

--- a/spec/workers/until_and_while_executing_reject_job_spec.rb
+++ b/spec/workers/until_and_while_executing_reject_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe UntilAndWhileExecutingRejectJob do
+  it_behaves_like "sidekiq with options" do
+    let(:options) do
+      {
+        "queue" => :working,
+        "retry" => true,
+        "lock" => :until_and_while_executing,
+        "on_conflict" => { client: :reject, server: :reject },
+      }
+    end
+  end
+
+  it "rejects the job successfully" do
+    Sidekiq::Testing.disable! do
+      set = Sidekiq::ScheduledSet.new
+
+      described_class.perform_at(Time.now + 30, 1)
+      expect(set.size).to eq(1)
+
+      expect(described_class.perform_at(Time.now + 30, 1)).to be_nil
+
+      set.each(&:delete)
+    end
+  end
+
+  it "rejects job successfully when using perform_in" do
+    Sidekiq::Testing.disable! do
+      set = Sidekiq::ScheduledSet.new
+
+      described_class.perform_in(30, 1)
+      expect(set.size).to eq(1)
+
+      expect(described_class.perform_in(30, 1)).to be_nil
+
+      set.each(&:delete)
+    end
+  end
+end

--- a/spec/workers/until_and_while_executing_replace_job_spec.rb
+++ b/spec/workers/until_and_while_executing_replace_job_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe UntilAndWhileExecutingReplaceJob do
+  it_behaves_like "sidekiq with options" do
+    let(:options) do
+      {
+        "queue" => :working,
+        "retry" => true,
+        "lock" => :until_and_while_executing,
+        "on_conflict" => { client: :replace, server: :reschedule },
+      }
+    end
+  end
+
+  it "replaces the previous job successfully" do
+    Sidekiq::Testing.disable! do
+      set = Sidekiq::ScheduledSet.new
+
+      described_class.perform_at(Time.now + 30, "unique", "first argument")
+      expect(set.size).to eq(1)
+      expect(set.first.item["args"]).to eq(["unique", "first argument"])
+
+      job_id = described_class.perform_at(Time.now + 30, "unique", "new argument")
+      expect(job_id).not_to be_nil
+      expect(set.size).to eq(1)
+      expect(set.first.item["args"]).to eq(["unique", "new argument"])
+
+      set.each(&:delete)
+    end
+  end
+
+  it "replaces the previous job successfully when using perform_in" do
+    Sidekiq::Testing.disable! do
+      set = Sidekiq::ScheduledSet.new
+
+      described_class.perform_in(30, "unique", "first argument")
+      expect(set.size).to eq(1)
+      expect(set.first.item["args"]).to eq(["unique", "first argument"])
+
+      job_id = described_class.perform_in(30, "unique", "new argument")
+      expect(job_id).not_to be_nil
+      expect(set.size).to eq(1)
+      expect(set.first.item["args"]).to eq(["unique", "new argument"])
+
+      set.each(&:delete)
+    end
+  end
+end


### PR DESCRIPTION
Close #629

The replace strategy creates a new lock after deleting the old lock and the old job. After a lock has been achieved we need to allow the worker to yield in that specific scenario.

@dsander can you check if this solves the problem for you? 