### PR TITLE
Fixing reschedule when using a non default queue

### DIFF
--- a/lib/sidekiq_unique_jobs/on_conflict/reschedule.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/reschedule.rb
@@ -21,7 +21,7 @@ module SidekiqUniqueJobs
       #   This will mess up sidekiq stats because a new job is created
       def call
         if sidekiq_worker_class?
-          if worker_class.perform_in(5, *item[ARGS])
+          if worker_class.set(queue: item["queue"].to_sym).perform_in(5, *item[ARGS])
             reflect(:rescheduled, item)
           else
             reflect(:reschedule_failed, item)

--- a/spec/sidekiq_unique_jobs/on_conflict/reschedule_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/reschedule_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reschedule do
 
     context "when pushed" do
       before do
-        allow(UniqueJobOnConflictReschedule).to receive(:set).with(queue: :default)
+        allow(UniqueJobOnConflictReschedule).to receive(:set)
+          .with(queue: :default)
           .and_return(UniqueJobOnConflictReschedule)
         allow(UniqueJobOnConflictReschedule).to receive(:perform_in).and_call_original
       end
@@ -42,7 +43,8 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reschedule do
 
     context "when push fails" do
       before do
-        allow(UniqueJobOnConflictReschedule).to receive(:set).with(queue: :default)
+        allow(UniqueJobOnConflictReschedule).to receive(:set)
+          .with(queue: :default)
           .and_return(UniqueJobOnConflictReschedule)
         allow(UniqueJobOnConflictReschedule).to receive(:perform_in).and_return(nil)
       end

--- a/spec/sidekiq_unique_jobs/on_conflict/reschedule_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/reschedule_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reschedule do
   let(:item) do
     { "class" => worker_class,
       "lock_digest" => lock_digest,
-      "args" => [1, 2] }
+      "args" => [1, 2],
+      "queue" => "default" }
   end
 
   describe "#call" do
@@ -19,6 +20,8 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reschedule do
 
     context "when pushed" do
       before do
+        allow(UniqueJobOnConflictReschedule).to receive(:set).with(queue: :default)
+          .and_return(UniqueJobOnConflictReschedule)
         allow(UniqueJobOnConflictReschedule).to receive(:perform_in).and_call_original
       end
 
@@ -39,6 +42,8 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reschedule do
 
     context "when push fails" do
       before do
+        allow(UniqueJobOnConflictReschedule).to receive(:set).with(queue: :default)
+          .and_return(UniqueJobOnConflictReschedule)
         allow(UniqueJobOnConflictReschedule).to receive(:perform_in).and_return(nil)
       end
 


### PR DESCRIPTION
When a job uses a non default queue in it's `sidekiq_options`, the `on_conflict` strategy still enqueues the job into the `default` queue even though, the queue information is available in `item`.

The MR fixes this by calling `set(queue: item['queue'].to_sym)` before `perform_in` in reschedule. It assumes that `item` always contains queue.