### PR TITLE
fix NoMethodError when timeout is nil

### DIFF
--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -241,7 +241,7 @@ module SidekiqUniqueJobs
     def primed_async(conn, wait = nil, &block)
       primed_jid = Concurrent::Promises
                    .future(conn) { |red_con| pop_queued(red_con, wait) }
-                   .value(add_drift(wait || config.timeout))
+                   .value(add_drift(wait || config.timeout || 0))
 
       handle_primed(primed_jid, &block)
     end


### PR DESCRIPTION
This fixes https://github.com/mhenrixon/sidekiq-unique-jobs/issues/675 where the timeout being set to `nil` can cause a NoMethodError