### PR TITLE
Fixes an issue with wrong number of arguments

### DIFF
--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -188,7 +188,7 @@ module SidekiqUniqueJobs
     # @yieldparam [string] job_id the sidekiq JID
     # @yieldreturn [void] whatever the calling block returns
     def lock!(conn, primed_method, wait = nil)
-      return yield job_id if locked?(conn)
+      return yield if locked?(conn)
 
       enqueue(conn) do |queued_jid|
         reflect(:debug, item, queued_jid)
@@ -199,7 +199,7 @@ module SidekiqUniqueJobs
           locked_jid = call_script(:lock, key.to_a, argv, conn)
           if locked_jid
             reflect(:debug, :locked, item, locked_jid)
-            return yield job_id
+            return yield
           end
         end
       end

--- a/spec/sidekiq_unique_jobs/lock/until_expired_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/until_expired_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe SidekiqUniqueJobs::Lock::UntilExpired do
 
     it "keeps lock after executing" do
       process_one.lock
-      process_one.execute {}
+      blk = -> {}
+      process_one.execute(&blk)
       expect(process_one).to be_locked
     end
   end


### PR DESCRIPTION
**Describe the bug**

The following error gets raised for the `until_expired` lock.

```
     ArgumentError:
       wrong number of arguments (given 1, expected 0)
```

**Expected behavior**

The error does not get raised.

**Current behavior**

The error above gets raised when a worker uses the `until_expired` lock.

**Worker class**

```ruby
class MyWorker
  include Sidekiq::Worker
  sidekiq_options lock: :until_expired, lock_ttl: 60
  def perform(args); end
end
```

**Additional context**

It looks like it this error has not been noticed before due to some difference in implementations of lambda/proc in ruby.