### PR TITLE
Fix worker validator

### DIFF
--- a/lib/sidekiq_unique_jobs/lock_config.rb
+++ b/lib/sidekiq_unique_jobs/lock_config.rb
@@ -113,13 +113,13 @@ module SidekiqUniqueJobs
 
     # the strategy to use as conflict resolution from sidekiq client
     def on_client_conflict
-      @on_client_conflict ||= on_conflict["client"] if on_conflict.is_a?(Hash)
+      @on_client_conflict ||= on_conflict["client"] || on_conflict[:client] if on_conflict.is_a?(Hash)
       @on_client_conflict ||= on_conflict
     end
 
     # the strategy to use as conflict resolution from sidekiq server
     def on_server_conflict
-      @on_server_conflict ||= on_conflict["server"] if on_conflict.is_a?(Hash)
+      @on_server_conflict ||= on_conflict["server"] || on_conflict[:server] if on_conflict.is_a?(Hash)
       @on_server_conflict ||= on_conflict
     end
   end


### PR DESCRIPTION
When setting a worker like so

```ruby
# frozen_string_literal: true

class DemoJob

  include Sidekiq::Worker

  sidekiq_options queue: :low_priority,
                  lock: :until_and_while_executing,
                  on_conflict: {
                    client: :replace,
                    server: :raise,
                  }

  def perform(stub_id)
    p stub_id
  end
end
```

the rspec matcher passes because the `get_sidekiq_options` method returns something like

```ruby
{
  "retry"=>3,
  "queue"=>:low_priority,
  "lock"=>:until_and_while_executing,
  "on_conflict"=>{ :client => :replace, :server => :raise }
}
```
since the `on_conflict` hash have symbol keys, the validator ends up returning valid.

This PR adds a check on the symbol keys just be sure we are checking the correct places.

Let me know if there's something else I can do to help in that fix :)