### PR TITLE
Quote '3.0' to ensure CI uses Ruby 3.0.x for the 3.0 entry

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The 3.0 in the CI configuration needs to be quoted or it will be truncated to '3'.  This loads the latest Ruby 3 version, which at time of writing is Ruby 3.1.1.

See a recent CI run:

<img width="1349" alt="Screen Shot 2022-03-10 at 8 15 18 PM" src="https://user-images.githubusercontent.com/421488/157801189-74f365fb-6bb1-4572-af69-79bdd9668052.png">

