### PR TITLE
Abort Ruby Reaper when sidekiq queues are full

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -59,6 +59,7 @@ detectors:
       - SidekiqUniqueJobs::OnConflict::Reject#push_to_deadset
       - SidekiqUniqueJobs::Orphans::RubyReaper#active?
       - SidekiqUniqueJobs::Orphans::RubyReaper#entries
+      - SidekiqUniqueJobs::Orphans::RubyReaper#queues_very_full?
       - SidekiqUniqueJobs::Redis::Entity#exist?
       - SidekiqUniqueJobs::Web::Helpers#cparams
       - SidekiqUniqueJobs::Web::Helpers#display_lock_args
@@ -153,6 +154,7 @@ detectors:
       - SidekiqUniqueJobs::Orphans::RubyReaper#enqueued?
       - SidekiqUniqueJobs::Orphans::RubyReaper#entries
       - SidekiqUniqueJobs::Orphans::RubyReaper#orphans
+      - SidekiqUniqueJobs::Orphans::RubyReaper#queues_very_full?
       - SidekiqUniqueJobs::Profiler#self.stop
       - SidekiqUniqueJobs::Script::Caller#call_script
       - SidekiqUniqueJobs::Script::Caller#extract_args

--- a/.reek.yml
+++ b/.reek.yml
@@ -111,6 +111,7 @@ detectors:
       - SidekiqUniqueJobs::OnConflict::Reject#push_to_deadset
       - SidekiqUniqueJobs::Orphans::RubyReaper#active?
       - SidekiqUniqueJobs::Orphans::RubyReaper#enqueued?
+      - SidekiqUniqueJobs::Orphans::RubyReaper#queues_very_full?
       - SidekiqUniqueJobs::UpgradeLocks#keys_for_digest
   RepeatedConditional:
     exclude:

--- a/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
+++ b/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
@@ -15,6 +15,9 @@ module SidekiqUniqueJobs
       # @return [String] the suffix for :RUN locks
       RUN_SUFFIX = ":RUN"
       #
+      # @return [Integer] the maximum combined length of sidekiq queues for running the reaper
+      MAX_QUEUE_LENGTH = 1000
+      #
       # @!attribute [r] digests
       #   @return [SidekiqUniqueJobs::Digests] digest collection
       attr_reader :digests
@@ -46,6 +49,8 @@ module SidekiqUniqueJobs
       # @return [Integer] the number of reaped locks
       #
       def call
+        return if queues_very_full?
+
         BatchDelete.call(orphans, conn)
       end
 
@@ -210,6 +215,23 @@ module SidekiqUniqueJobs
 
           deleted_size = initial_size - conn.llen(queue_key)
         end
+      end
+
+      # If sidekiq queues are very full, it becomes highly inefficient for the reaper
+      # because it must check every queued job to verify a digest is safe to delete
+      # The reaper checks queued jobs in batches of 50, adding 2 reads per digest
+      # With a queue length of 1,000 jobs, that's over 20 extra reads per digest.
+      def queues_very_full?
+        total_queue_size = 0
+        Sidekiq.redis do |conn|
+          queues(conn) do |queue|
+            queue_size = conn.llen("queue:#{queue}")
+            total_queue_size += queue_size
+
+            return true if total_queue_size > MAX_QUEUE_LENGTH
+          end
+        end
+        total_queue_size > MAX_QUEUE_LENGTH
       end
 
       #

--- a/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
+++ b/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
@@ -225,13 +225,12 @@ module SidekiqUniqueJobs
         total_queue_size = 0
         Sidekiq.redis do |conn|
           queues(conn) do |queue|
-            queue_size = conn.llen("queue:#{queue}")
-            total_queue_size += queue_size
+            total_queue_size += conn.llen("queue:#{queue}")
 
             return true if total_queue_size > MAX_QUEUE_LENGTH
           end
         end
-        total_queue_size > MAX_QUEUE_LENGTH
+        false
       end
 
       #

--- a/spec/sidekiq_unique_jobs/orphans/ruby_reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/ruby_reaper_spec.rb
@@ -95,4 +95,16 @@ RSpec.describe SidekiqUniqueJobs::Orphans::RubyReaper do
       end
     end
   end
+
+  describe "#call" do
+    before do
+      stub_const("SidekiqUniqueJobs::Orphans::RubyReaper::MAX_QUEUE_LENGTH", 3)
+      4.times { push_item(item) }
+    end
+    it 'quits early if sidekiq queues are very full' do
+      expect(service).not_to receive(:orphans)
+
+      service.call
+    end
+  end
 end


### PR DESCRIPTION
This is an attempt to resolve https://github.com/mhenrixon/sidekiq-unique-jobs/issues/670 .

This change is quite blunt - it silently returns from the ruby reaper if queues are longer than an arbitrary number (1,000 jobs). I'm conscious this may not be ideal for all use cases, but there are a lot of settings already. In my experience, the performance of the reaper degrades so much in these circumstances, it's not worth running, and it will occupy resources you could be using to clear that queue!

If there's anything I missed or further changes from a stylistic or architectural perspective that might help, just let me know and I'll be happy to work on this some more.