### PR TITLE
Make sure we reflect on execution failure

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -33,10 +33,14 @@ module SidekiqUniqueJobs
       # Executes in the Sidekiq server process
       # @yield to the worker class perform method
       def execute
-        locksmith.execute do
+        executed = locksmith.execute do
           yield
           unlock_and_callback
         end
+
+        reflect(:execution_failed, item) unless executed
+
+        nil
       end
     end
   end

--- a/lib/sidekiq_unique_jobs/lock/until_expired.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_expired.rb
@@ -33,7 +33,9 @@ module SidekiqUniqueJobs
       # Executes in the Sidekiq server process
       # @yield to the worker class perform method
       def execute(&block)
-        locksmith.execute(&block)
+        executed = locksmith.execute(&block)
+
+        reflect(:execution_failed, item) unless executed
       end
     end
   end

--- a/lib/sidekiq_unique_jobs/lock/while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/while_executing.rb
@@ -47,7 +47,10 @@ module SidekiqUniqueJobs
             locksmith.unlock
           end
 
-          call_strategy(origin: :server, &block) unless executed
+          unless executed
+            reflect(:execution_failed, item)
+            call_strategy(origin: :server, &block)
+          end
         end
       end
 

--- a/spec/sidekiq_unique_jobs/lock/while_executing_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/while_executing_spec.rb
@@ -77,9 +77,10 @@ RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting do
       before do
         allow(strategy_one).to receive(:call).and_call_original
         allow(strategy_two).to receive(:call).and_call_original
+        allow(process_two).to receive(:reflect).and_call_original
       end
 
-      it "works" do
+      it "reflects execution_failed" do
         process_one.execute do
           process_two.execute { puts "BOGUS!" }
         end
@@ -87,6 +88,8 @@ RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting do
         expect(callback_one).to have_received(:call).once
         expect(strategy_one).not_to have_received(:call)
         expect(strategy_two).to have_received(:call).once
+
+        expect(process_two).to have_received(:reflect).with(:execution_failed, item_two)
       end
     end
 
@@ -99,7 +102,7 @@ RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting do
         expect { process_one.execute { raise "Hell" } }
           .to raise_error(RuntimeError, "Hell")
 
-        expect(process_one.locked?).to be(false)
+        expect(process_one).not_to be_locked
       end
     end
   end

--- a/spec/support/shared_examples/a_lockable_lock.rb
+++ b/spec/support/shared_examples/a_lockable_lock.rb
@@ -76,5 +76,12 @@ RSpec.shared_examples "an executing lock implementation" do
     it "prevents process_two from executing" do
       expect { process_two.execute { raise "Hell" } }.not_to raise_error
     end
+
+    it "reflects execution_failed on failure" do
+      allow(process_two).to receive(:reflect).and_call_original
+      process_two.execute { puts "Failed to execute" }
+
+      expect(process_two).to have_received(:reflect).with(:execution_failed, item_two)
+    end
   end
 end


### PR DESCRIPTION
It will be useful for debugging like below:

```ruby
SidekiqUniqueJobs.reflect do |on|
  on.duplicate do |item|
    keys = Sidekiq.redis(&:keys)

    Rails.logger.error(
      <<~EOS.squish
        Duplicate lock: #{item}. The following keys are present in redis: [#{keys.join(',')}]
      EOS
    )
  end

  on.execution_failed do |item|
    keys = Sidekiq.redis(&:keys)

    Rails.logger.error(
      <<~EOS.squish
        Failed to execute: #{item}. The following keys are present in redis: [#{keys.join(',')}]
      EOS
    )
  end
end
```

Signed-off-by: mhenrixon <mikael@mhenrixon.com>