### PR TITLE
Manually handle timeouts

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -175,6 +175,7 @@ detectors:
       - SidekiqUniqueJobs::LockConfig
       - SidekiqUniqueJobs::Locksmith
       - SidekiqUniqueJobs::Lock::BaseLock
+      - SidekiqUniqueJobs::Orphans::RubyReaper
       - SidekiqUniqueJobs::TimerTask
   TooManyMethods:
     exclude:
@@ -182,6 +183,7 @@ detectors:
       - SidekiqUniqueJobs::Locksmith
       - SidekiqUniqueJobs::Lock
       - SidekiqUniqueJobs::Orphans::Reaper
+      - SidekiqUniqueJobs::Orphans::RubyReaper
   UncommunicativeVariableName:
     exclude:
       - Hash#slice

--- a/bin/bundle
+++ b/bin/bundle
@@ -18,7 +18,7 @@ m = Module.new do
   end
 
   def env_var_version
-    ENV["BUNDLER_VERSION"]
+    ENV.fetch("BUNDLER_VERSION", nil)
   end
 
   def cli_arg_version # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -38,7 +38,7 @@ m = Module.new do
   end
 
   def gemfile
-    gemfile = ENV["BUNDLE_GEMFILE"]
+    gemfile = ENV.fetch("BUNDLE_GEMFILE", nil)
     return gemfile if gemfile && !gemfile.empty?
 
     File.expand_path("../Gemfile", __dir__)

--- a/lib/sidekiq_unique_jobs/orphans/manager.rb
+++ b/lib/sidekiq_unique_jobs/orphans/manager.rb
@@ -110,13 +110,7 @@ module SidekiqUniqueJobs
       # @return [Hash]
       #
       def timer_task_options
-        timer_task_options = { run_now: true, execution_interval: reaper_interval }
-
-        if VersionCheck.satisfied?(::Concurrent::VERSION, "< 1.1.10")
-          timer_task_options[:timeout_interval] = reaper_timeout
-        end
-
-        timer_task_options
+        { run_now: true, execution_interval: reaper_interval }
       end
 
       #
@@ -131,13 +125,6 @@ module SidekiqUniqueJobs
       #
       def reaper_interval
         SidekiqUniqueJobs.config.reaper_interval
-      end
-
-      #
-      # @see SidekiqUniqueJobs::Config#reaper_timeout
-      #
-      def reaper_timeout
-        SidekiqUniqueJobs.config.reaper_timeout
       end
 
       #

--- a/lib/tasks/changelog.rake
+++ b/lib/tasks/changelog.rake
@@ -17,7 +17,7 @@ COMMIT_CHANGELOG_CMD = "git commit -a -m 'Update changelog'"
 desc "Generate a Changelog"
 task :changelog do
   sh("git checkout main")
-  sh(*CHANGELOG_CMD.push(ENV["CHANGELOG_GITHUB_TOKEN"]))
+  sh(*CHANGELOG_CMD.push(ENV.fetch("CHANGELOG_GITHUB_TOKEN", nil)))
   sh(ADD_CHANGELOG_CMD)
   sh(COMMIT_CHANGELOG_CMD)
 end

--- a/myapp/bin/bundle
+++ b/myapp/bin/bundle
@@ -18,7 +18,7 @@ m = Module.new do
   end
 
   def env_var_version
-    ENV["BUNDLER_VERSION"]
+    ENV.fetch("BUNDLER_VERSION", nil)
   end
 
   def cli_arg_version # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -38,7 +38,7 @@ m = Module.new do
   end
 
   def gemfile
-    gemfile = ENV["BUNDLE_GEMFILE"]
+    gemfile = ENV.fetch("BUNDLE_GEMFILE", nil)
     return gemfile if gemfile && !gemfile.empty?
 
     File.expand_path("../Gemfile", __dir__)

--- a/myapp/config/initializers/sidekiq.rb
+++ b/myapp/config/initializers/sidekiq.rb
@@ -5,7 +5,7 @@ require "sidekiq-unique-jobs"
 
 Redis.exists_returns_integer = false
 
-REDIS = Redis.new(url: ENV["REDIS_URL"])
+REDIS = Redis.new(url: ENV.fetch("REDIS_URL", nil))
 
 Sidekiq.default_worker_options = {
   backtrace: true,
@@ -13,7 +13,7 @@ Sidekiq.default_worker_options = {
 }
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV["REDIS_URL"], driver: :hiredis }
+  config.redis = { url: ENV.fetch("REDIS_URL", nil), driver: :hiredis }
 
   config.client_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Client
@@ -21,7 +21,7 @@ Sidekiq.configure_client do |config|
 end
 
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV["REDIS_URL"], driver: :hiredis }
+  config.redis = { url: ENV.fetch("REDIS_URL", nil), driver: :hiredis }
 
   config.server_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Server

--- a/spec/sidekiq_unique_jobs/on_conflict/reject_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/reject_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reject do
   include_context "with a stubbed locksmith"
   let(:strategy) { described_class.new(item) }
   let(:deadset)  { instance_spy(Sidekiq::DeadSet) }
-  let(:payload)  { instance_spy(payload) }
+  let(:payload)  { instance_spy("payload") } # rubocop:disable RSpec/VerifiedDoubleReference
   let(:item) do
     { "jid" => "maaaahjid",
       "class" => "WhileExecutingRejectJob",

--- a/spec/sidekiq_unique_jobs/on_conflict/reject_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/reject_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reject do
   include_context "with a stubbed locksmith"
   let(:strategy) { described_class.new(item) }
   let(:deadset)  { instance_spy(Sidekiq::DeadSet) }
-  let(:payload)  { instance_spy("payload") }
+  let(:payload)  { instance_spy(payload) }
   let(:item) do
     { "jid" => "maaaahjid",
       "class" => "WhileExecutingRejectJob",

--- a/spec/sidekiq_unique_jobs/orphans/manager_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/manager_spec.rb
@@ -261,8 +261,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Manager do
 
       let(:expected_options) do
         { run_now: true,
-          execution_interval: SidekiqUniqueJobs.config.reaper_interval,
-          timeout_interval: SidekiqUniqueJobs.config.reaper_timeout }
+          execution_interval: SidekiqUniqueJobs.config.reaper_interval }
       end
 
       it { is_expected.to eq(expected_options) }
@@ -273,12 +272,6 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Manager do
     subject(:reaper_interval) { described_class.reaper_interval }
 
     it { is_expected.to eq(SidekiqUniqueJobs.config.reaper_interval) }
-  end
-
-  describe ".reaper_timeout" do
-    subject(:reaper_timeout) { described_class.reaper_timeout }
-
-    it { is_expected.to eq(SidekiqUniqueJobs.config.reaper_timeout) }
   end
 
   describe ".register_reaper_process" do

--- a/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
     context "when given a connection" do
       let(:conn)       { instance_spy(ConnectionPool) }
       let(:reaper)     { :ruby }
-      let(:reaper_spy) { instance_spy("SidekiqUniqueJobs::Orphans::Reaper") }
+      let(:reaper_spy) { instance_spy(described_class) }
 
       before do
         allow(reaper_spy).to receive(:call)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ Sidekiq.default_worker_options = {
 }
 
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV["REDIS_URL"], driver: :hiredis }
+  config.redis = { url: ENV.fetch("REDIS_URL", nil), driver: :hiredis }
 
   config.server_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Server
@@ -46,7 +46,7 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV["REDIS_URL"], driver: :hiredis }
+  config.redis = { url: ENV.fetch("REDIS_URL", nil), driver: :hiredis }
 
   config.client_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Client
@@ -55,7 +55,7 @@ end
 
 SidekiqUniqueJobs.configure do |config|
   config.logger.level = Logger.const_get(LOGLEVEL)
-  config.debug_lua    = %w[1 true].include?(ENV["DEBUG_LUA"])
+  config.debug_lua    = %w[1 true].include?(ENV.fetch("DEBUG_LUA", nil))
   config.max_history  = 10
   config.lock_info    = true
 end


### PR DESCRIPTION
This should prevent the problems a lot of people have had with the timer task since concurrent ruby removed the timeout handling.

Closes #701 