### PR TITLE
Fix Sidekiq::Worker.clear_all override not being applied

### DIFF
--- a/lib/sidekiq_unique_jobs/testing.rb
+++ b/lib/sidekiq_unique_jobs/testing.rb
@@ -91,15 +91,6 @@ module Sidekiq
       end
 
       #
-      # Clears all jobs for this worker and removes all locks
-      #
-      def clear_all
-        super
-
-        SidekiqUniqueJobs::Digests.new.delete_by_pattern("*", count: 10_000)
-      end
-
-      #
       # Prepends deletion of locks to clear
       #
       module ClassMethods
@@ -124,5 +115,21 @@ module Sidekiq
     module ClassMethods
       prepend Overrides::ClassMethods
     end
+
+    #
+    # Prepends singleton methods to Sidekiq::Worker
+    #
+    module SignletonOverrides
+      #
+      # Clears all jobs for this worker and removes all locks
+      #
+      def clear_all
+        super
+
+        SidekiqUniqueJobs::Digests.new.delete_by_pattern("*", count: 10_000)
+      end
+    end
+
+    singleton_class.prepend SignletonOverrides
   end
 end

--- a/spec/sidekiq/testing_spec.rb
+++ b/spec/sidekiq/testing_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe "sidekiq/testing" do
+  describe "Sidekiq::Worker.clear_all" do
+    it "unlocks all unique locks" do
+      expect(UntilAndWhileExecutingJob.perform_async).not_to be_nil
+      Sidekiq::Worker.clear_all
+      expect(UntilAndWhileExecutingJob.perform_async).not_to be_nil
+    end
+  end
+end

--- a/spec/sidekiq/worker_spec.rb
+++ b/spec/sidekiq/worker_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe "sidekiq/testing" do
-  describe "Sidekiq::Worker.clear_all" do
+RSpec.describe "Sidekiq::Worker" do
+  describe "#clear_all" do
     it "unlocks all unique locks" do
       expect(UntilAndWhileExecutingJob.perform_async).not_to be_nil
       Sidekiq::Worker.clear_all


### PR DESCRIPTION
Since the method is defined as a singleton the testing override needs to
be prepended to the singleton class.