### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds Dependabot for GitHub Actions, ensuring those actions stay up to date.

As the checkout action in the current configuration is out of date, it is expected that Dependabot will open a PR if and when this is merged.