### PR TITLE
Do not run reaper if registration failed

### DIFF
--- a/lib/sidekiq_unique_jobs/orphans/manager.rb
+++ b/lib/sidekiq_unique_jobs/orphans/manager.rb
@@ -39,7 +39,9 @@ module SidekiqUniqueJobs
         self.task = test_task || default_task
 
         with_logging_context do
-          register_reaper_process
+          got_lock = register_reaper_process
+          return unless got_lock
+
           log_info("Starting Reaper")
 
           task.add_observer(Observer.new)


### PR DESCRIPTION
I might be misunderstanding the intended purpose of the manager process, but it seems like the reaper should run if registration was successful