### PR TITLE
Avoid skipping ranges when looping through queues

### DIFF
--- a/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
+++ b/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
@@ -229,6 +229,7 @@ module SidekiqUniqueJobs
 
         loop do
           range_start = (page * page_size) - deleted_size
+
           range_end   = range_start + page_size - 1
           entries     = conn.lrange(queue_key, range_start, range_end)
           page       += 1
@@ -238,6 +239,9 @@ module SidekiqUniqueJobs
           entries.each(&block)
 
           deleted_size = initial_size - conn.llen(queue_key)
+
+          # The queue is growing, not shrinking, just keep looping
+          deleted_size = 0 if deleted_size.negative?
         end
       end
 


### PR DESCRIPTION
When queues are very full and/or very active, the ruby reaper can't give absolute guarantees because it doesn't run as a single atomic action, but we can eliminate some edge cases.

In this instance, the reaper anticipates that a queue might *empty*, from the front, in which case ranges need to be adjusted downward to ensure every job is checked. However, in the case where the queue *grows* (at the back), this calculation of "next_page - (initial_size - current_size))" means *skipping over* some jobs.