### PR TITLE
Ensure batch delete removes expiring locks

### DIFF
--- a/lib/sidekiq_unique_jobs/batch_delete.rb
+++ b/lib/sidekiq_unique_jobs/batch_delete.rb
@@ -91,6 +91,7 @@ module SidekiqUniqueJobs
           chunk.each do |digest|
             del_digest(pipeline, digest)
             pipeline.zrem(SidekiqUniqueJobs::DIGESTS, digest)
+            pipeline.zrem(SidekiqUniqueJobs::EXPIRING_DIGESTS, digest)
             @count += 1
           end
         end


### PR DESCRIPTION
Hi @mhenrixon thanks so much for the positive response to #721 

Unfortunately I missed a spot! 😅  In truth, I think it's unnecessary to use batch delete when removing expiring locks - it would be enough to just remove the digests from the ZSET because all other elements are expired by redis, but since I *did* use batch delete - it's really important that batch delete removes from this new ZSET!

Previously, I only updated `lock.lua` to put these digests into a separate ZSET because that's what the locksmith calls, but when trying to verify this fix in tests, I found `lock.rb` needed to be updated as well, so that's here too.