### PR TITLE
Lower bounds on sidekiq dependency

### DIFF
--- a/sidekiq-unique-jobs.gemspec
+++ b/sidekiq-unique-jobs.gemspec
@@ -73,7 +73,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "brpoplpush-redis_script", "> 0.1.1", "<= 2.0.0"
   spec.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.5"
-  spec.add_dependency "sidekiq", ">= 5.0", "< 8.0"
+  spec.add_dependency "sidekiq", ">= 5.0", "< 7.0"
   spec.add_dependency "thor", ">= 0.20", "< 3.0"
   spec.metadata = {
     "rubygems_mfa_required" => "true",


### PR DESCRIPTION
#642 bumped the bounds on the sidekiq dependency to `< 8.0`, but I believe that was incorrect: this gem is not compatible with sidekiq 7 (see this issue: https://github.com/mhenrixon/sidekiq-unique-jobs/issues/736). I think work is being done to resolve this, but in the meantime would it make sense to release a bounds change?