### PR TITLE
fix: backport the fix for the return value of #deep_transform_keys

### DIFF
--- a/lib/sidekiq_unique_jobs/core_ext.rb
+++ b/lib/sidekiq_unique_jobs/core_ext.rb
@@ -98,7 +98,7 @@ class Hash
     def _deep_transform_keys_in_object(object, &block)
       case object
       when Hash
-        object.each_with_object({}) do |(key, value), result|
+        object.each_with_object(self.class.new) do |(key, value), result|
           result[yield(key)] = _deep_transform_keys_in_object(value, &block)
         end
       when Array

--- a/spec/sidekiq_unique_jobs/core_ext_spec.rb
+++ b/spec/sidekiq_unique_jobs/core_ext_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe "core_ext.rb" do
     end
   end
 
+  describe "ExtendedHash" do
+    before do
+      stub_const("ExtendedHash", Hash)
+    end
+
+    let(:hash) { ExtendedHash[:test, :me, :not, :me] }
+
+    describe "#deep_transform_keys" do
+      subject(:deep_transform_keys) { hash.deep_transform_keys(&:to_s) }
+
+      it { is_expected.to be_a(ExtendedHash) }
+    end
+  end
+
   describe Array do
     let(:array)         { [1, 2, nil, last_argument] }
     let(:last_argument) { Object.new }


### PR DESCRIPTION
The behavior of `Hash#deep_transform_keys` was fixed in Rails a while ago, but is still not up-to-date in `sidekiq-unique-jobs`, returning unexpected instance class when you call it on descendants of `Hash` like `ActiveSupport::HashWithIndifferentAccess`. Futhermore, the gem is able to monkey-patch `Hash` implementation and break the method behavior if it gets loaded before `ActiveSupport::HashWithIndifferentAccess`.

The original fix: https://github.com/rails/rails/commit/f5e597638853e5550509347254889d50c738ea56