### PR TITLE
Fix active worker detection by using correct keys

### DIFF
--- a/lib/sidekiq_unique_jobs/lua/shared/_find_digest_in_process_set.lua
+++ b/lib/sidekiq_unique_jobs/lua/shared/_find_digest_in_process_set.lua
@@ -15,7 +15,7 @@ local function find_digest_in_process_set(digest, threshold)
     log_debug("Found number of processes:", #processes, "next cursor:", next_process_cursor)
 
     for _, process in ipairs(processes) do
-      local workers_key = process .. ":workers"
+      local workers_key = process .. ":work"
       log_debug("searching in process set:", process,
                 "for digest:", digest,
                 "cursor:", process_cursor)

--- a/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
+++ b/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
@@ -191,7 +191,7 @@ module SidekiqUniqueJobs
               else
                 pipeline.exists(key)
               end
-              pipeline.hgetall("#{key}:workers")
+              pipeline.hgetall("#{key}:work")
             end
 
             next unless valid

--- a/spec/sidekiq_unique_jobs/lua/reap_orphans_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/reap_orphans_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "reap_orphans.lua" do
     context "with job" do
       let(:process_key) { "process-id" }
       let(:thread_id)   { "thread-id" }
-      let(:worker_key)  { "#{process_key}:workers" }
+      let(:worker_key)  { "#{process_key}:work" }
 
       before do
         SidekiqUniqueJobs.redis do |conn|

--- a/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
         context "with job in process" do
           let(:process_key)    { "process-id" }
           let(:thread_id)      { "thread-id" }
-          let(:worker_key)     { "#{process_key}:workers" }
+          let(:worker_key)     { "#{process_key}:work" }
           let(:created_at)     { (Time.now - reaper_timeout).to_f }
           let(:reaper_timeout) { SidekiqUniqueJobs.config.reaper_timeout }
 


### PR DESCRIPTION
Hello,
We are using this gem for some of our products at [marketer.tech](https://www.marketer.tech/).

**The problem**:
Recently we've spotted an issue with one our workers. The lock was not working and the same cron job was processed multiple times. After some investigation, we noticed that the reaper removes active locks which is incorrect behavior.

**Root cause of the issue**
It turns out that the `active?` method does not find any active workers because of the naming issue. Sidekiq sets the keys with "#{key}:work" instead of "#{key}:workers". The same happens to Lua reaper.

**Solution:**
Rename keys from `:workers` to `:work` since that's the correct name set in Redis:
![Zrzut ekranu 2023-02-14 o 13 04 25](https://user-images.githubusercontent.com/7230086/218733195-fe87129f-59cd-4ae7-8a67-85c395a04d04.png)


**QA**:
We tested those changes with our app and both reapers (Ruby & Lua) no longer remove active locks.
