### PR TITLE
fix lock & changelog times on web interface

### DIFF
--- a/lib/sidekiq_unique_jobs/lock.rb
+++ b/lib/sidekiq_unique_jobs/lock.rb
@@ -46,11 +46,11 @@ module SidekiqUniqueJobs
     # @param [Timstamp, Float] time nil optional timestamp to initiate this lock with
     #
     def initialize(key, time: nil)
-      @key        = get_key(key)
+      @key = get_key(key)
       time = time.is_a?(Float) ? time : time.to_f
-      if time.nonzero?
-        @created_at = time
-      end
+      return unless time.nonzero?
+
+      @created_at = time
     end
 
     #

--- a/lib/sidekiq_unique_jobs/lock.rb
+++ b/lib/sidekiq_unique_jobs/lock.rb
@@ -47,7 +47,10 @@ module SidekiqUniqueJobs
     #
     def initialize(key, time: nil)
       @key        = get_key(key)
-      @created_at = time.is_a?(Float) ? time : time.to_f
+      time = time.is_a?(Float) ? time : time.to_f
+      if time.nonzero?
+        @created_at = time
+      end
     end
 
     #

--- a/lib/sidekiq_unique_jobs/web/helpers.rb
+++ b/lib/sidekiq_unique_jobs/web/helpers.rb
@@ -146,6 +146,8 @@ module SidekiqUniqueJobs
       # @return [String] a html safe string with relative time information
       #
       def safe_relative_time(time)
+        return unless time
+
         time = parse_time(time)
 
         relative_time(time)

--- a/lib/sidekiq_unique_jobs/web/views/changelogs.erb
+++ b/lib/sidekiq_unique_jobs/web/views/changelogs.erb
@@ -42,7 +42,7 @@
       <tbody>
         <% @changelogs.each do |changelog| %>
           <tr  class="changelog-row">
-            <td><%= "bogus" %></td>
+            <td><%= safe_relative_time(changelog['time']) || "bogus" %></td>
             <td><%= changelog["digest"] %></td>
             <td><%= changelog["script"] %></td>
             <td><%= changelog["job_id"] %></td>


### PR DESCRIPTION
Fixes part of #761 - resolves the time showing as 53 years ago that looks to be caused by a nil.to_f = 0.0 = to date = 1970-01-01. Also updated the changelog view to show times if present instead of a hardcoded 'bogus'

![image](https://user-images.githubusercontent.com/10139527/224131039-847c65be-21cf-4865-ae74-cb859215ab79.png)

![image](https://user-images.githubusercontent.com/10139527/224131075-d6c17961-5b96-49cf-b7ea-425c083fb179.png)

Please let me know if you'd like any tweaks/changes or if I missed something entirely - I'm *very* fresh to this codebase