### PR TITLE
Hide lock info debug suggestion on lock page if it's already enabled.

### DIFF
--- a/lib/sidekiq_unique_jobs/web/views/lock.erb
+++ b/lib/sidekiq_unique_jobs/web/views/lock.erb
@@ -7,9 +7,11 @@
   <div class="col-sm-7 table-responsive">
     <% if @lock.info.none? %>
     <h3>No Lock Information Available</h3>
-    <p>To use it turn the following setting on:
-      <code>SidekiqUniqueJobs.config.lock_info = true</code>
-    </p>
+    <% unless SidekiqUniqueJobs.config.lock_info %>
+      <p>To use it turn the following setting on:
+        <code>SidekiqUniqueJobs.config.lock_info = true</code>
+      </p>
+    <% end %>
     <% else %>
     <table class="table table-striped table-bordered table-white table-hover">
       <caption>Information about lock</caption>


### PR DESCRIPTION
Super small change to hide the suggestion to turn the lock_info config on if the config value is already enabled.

potentially save some head scratching if you have the config enabled but are still seeing that message when you don't have lock info for whatever reason