### PR TITLE
fix rubocop

### DIFF
--- a/spec/sidekiq/api_spec.rb
+++ b/spec/sidekiq/api_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe "Sidekiq::Api" do
   describe Sidekiq::SortedEntry::UniqueExtension do
     it "deletes uniqueness lock on delete" do
       expect(JustAWorker.perform_in(60 * 60 * 3, "foo" => "bar")).to be_truthy
-      expect(unique_keys).not_to match_array([])
+      expect(unique_keys).not_to eq([])
 
       Sidekiq::ScheduledSet.new.each(&:delete)
-      expect(unique_keys).to match_array([])
+      expect(unique_keys).to eq([])
 
       expect(JustAWorker.perform_in(60 * 60 * 3, "boo" => "far")).to be_truthy
     end
 
     it "deletes uniqueness lock on remove_job" do
       expect(JustAWorker.perform_in(60 * 60 * 3, "foo" => "bar")).to be_truthy
-      expect(unique_keys).not_to match_array([])
+      expect(unique_keys).not_to eq([])
 
       Sidekiq::ScheduledSet.new.each do |entry|
         entry.send(:remove_job) do |message|
@@ -44,7 +44,7 @@ RSpec.describe "Sidekiq::Api" do
           )
         end
       end
-      expect(unique_keys).to match_array([])
+      expect(unique_keys).to eq([])
       expect(JustAWorker.perform_in(60 * 60 * 3, "boo" => "far")).to be_truthy
     end
   end
@@ -53,18 +53,18 @@ RSpec.describe "Sidekiq::Api" do
     describe Sidekiq::JobRecord::UniqueExtension do
       it "deletes uniqueness lock on delete" do
         jid = JustAWorker.perform_async("roo" => "baf")
-        expect(unique_keys).not_to match_array([])
+        expect(unique_keys).not_to eq([])
         Sidekiq::Queue.new("testqueue").find_job(jid).delete
-        expect(unique_keys).to match_array([])
+        expect(unique_keys).to eq([])
       end
     end
   else
     describe Sidekiq::Job::UniqueExtension do
       it "deletes uniqueness lock on delete" do
         jid = JustAWorker.perform_async("roo" => "baf")
-        expect(unique_keys).not_to match_array([])
+        expect(unique_keys).not_to eq([])
         Sidekiq::Queue.new("testqueue").find_job(jid).delete
-        expect(unique_keys).to match_array([])
+        expect(unique_keys).to eq([])
       end
     end
   end
@@ -72,38 +72,38 @@ RSpec.describe "Sidekiq::Api" do
   describe Sidekiq::Queue::UniqueExtension do
     it "deletes uniqueness locks on clear" do
       JustAWorker.perform_async("oob" => "far")
-      expect(unique_keys).not_to match_array([])
+      expect(unique_keys).not_to eq([])
       Sidekiq::Queue.new("testqueue").clear
-      expect(unique_keys).to match_array([])
+      expect(unique_keys).to eq([])
     end
   end
 
   describe Sidekiq::JobSet::UniqueExtension do
     it "deletes uniqueness locks on clear" do
       JustAWorker.perform_in(60 * 60 * 3, "roo" => "fab")
-      expect(unique_keys).not_to match_array([])
+      expect(unique_keys).not_to eq([])
       Sidekiq::JobSet.new("schedule").clear
-      expect(unique_keys).to match_array([])
+      expect(unique_keys).to eq([])
     end
   end
 
   describe Sidekiq::ScheduledSet::UniqueExtension do
     it "deletes uniqueness locks on clear" do
       JustAWorker.perform_in(60 * 60 * 3, "roo" => "fab")
-      expect(unique_keys).not_to match_array([])
+      expect(unique_keys).not_to eq([])
       Sidekiq::ScheduledSet.new.clear
-      expect(unique_keys).to match_array([])
+      expect(unique_keys).to eq([])
     end
 
     it "deletes uniqueness locks on delete_by_score" do
       JustAWorker.perform_in(60 * 60 * 3, "roo" => "fab")
-      expect(unique_keys).not_to match_array([])
+      expect(unique_keys).not_to eq([])
       scheduled_set = Sidekiq::ScheduledSet.new
       scheduled_set.each do |job|
         scheduled_set.delete(job.score, job.jid)
       end
 
-      expect(unique_keys).to match_array([])
+      expect(unique_keys).to eq([])
     end
   end
 end

--- a/spec/sidekiq_unique_jobs/batch_delete_spec.rb
+++ b/spec/sidekiq_unique_jobs/batch_delete_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe SidekiqUniqueJobs::BatchDelete do
       call
 
       locks.all? do |lock|
-        expect(lock.all_jids).to match_array([])
-        expect(unique_keys).to match_array([])
+        expect(lock.all_jids).to eq([])
+        expect(unique_keys).to eq([])
       end
     end
   end

--- a/spec/sidekiq_unique_jobs/changelog_spec.rb
+++ b/spec/sidekiq_unique_jobs/changelog_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
     let(:count)   { nil }
 
     context "when no entries exist" do
-      it { is_expected.to match_array([]) }
+      it { is_expected.to eq([]) }
     end
 
     context "when entries exist" do
@@ -174,13 +174,13 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
         }
       end
 
-      it { is_expected.to match_array([locked_entry, queued_entry]) }
+      it { is_expected.to contain_exactly(locked_entry, queued_entry) }
 
       context "when given count 1" do
         let(:count) { 1 }
 
         # count only is considered per iteration, this would have iterated twice
-        it { is_expected.to match_array([locked_entry, queued_entry]) }
+        it { is_expected.to contain_exactly(locked_entry, queued_entry) }
       end
     end
   end
@@ -193,7 +193,7 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
     let(:page_size) { 1 }
 
     context "when no entries exist" do
-      it { is_expected.to match_array([0, 0, []]) }
+      it { is_expected.to contain_exactly(0, 0, []) }
     end
 
     context "when entries exist" do
@@ -221,7 +221,7 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
         }
       end
 
-      it { is_expected.to match_array([2, anything, a_collection_including(kind_of(Hash))]) }
+      it { is_expected.to contain_exactly(2, anything, a_collection_including(kind_of(Hash))) }
     end
   end
 end

--- a/spec/sidekiq_unique_jobs/digests_spec.rb
+++ b/spec/sidekiq_unique_jobs/digests_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe SidekiqUniqueJobs::Digests do
 
     it "deletes all matching digests" do
       expect(delete_by_pattern).to be_a(Integer)
-      expect(digests.entries).to match_array([])
+      expect(digests.entries).to match_array([]) # rubocop:todo RSpec/MatchArray
     end
 
     it "logs performance info" do

--- a/spec/sidekiq_unique_jobs/lock/base_lock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/base_lock_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe SidekiqUniqueJobs::Lock::BaseLock do
   let(:lock)     { described_class.new(item, callback) }
-  let(:callback) { -> { p "debug" } } # rubocop:disable Lint/Debugger
+  let(:callback) { -> { p "debug" } }
   let(:strategy) { :replace }
   let(:jid)      { "bogusjobid" }
   let(:item) do

--- a/spec/sidekiq_unique_jobs/lock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SidekiqUniqueJobs::Lock do
 
     it "creates all expected keys in redis" do
       create
-      expect(keys).to match_array([key.digest, key.locked, key.info, key.changelog, key.digests])
+      expect(keys).to contain_exactly(key.digest, key.locked, key.info, key.changelog, key.digests)
       expect(create.locked_jids).to include(job_id)
     end
   end
@@ -54,13 +54,13 @@ RSpec.describe SidekiqUniqueJobs::Lock do
     subject(:all_jids) { entity.all_jids }
 
     context "when no locks exist" do
-      it { is_expected.to match_array([]) }
+      it { is_expected.to eq([]) }
     end
 
     context "when locks exists" do
       before { simulate_lock(key, job_id) }
 
-      it { is_expected.to match_array([job_id]) }
+      it { is_expected.to contain_exactly(job_id) }
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe SidekiqUniqueJobs::Lock do
     it "creates keys and adds job_id to locked hash" do
       expect { lock }.to change { entity.locked_jids }.to([job_id])
 
-      expect(keys).to match_array([key.digest, key.locked, key.info, key.changelog, key.digests])
+      expect(keys).to contain_exactly(key.digest, key.locked, key.info, key.changelog, key.digests)
     end
   end
 
@@ -82,7 +82,7 @@ RSpec.describe SidekiqUniqueJobs::Lock do
     it "creates keys and adds job_id to locked hash" do
       expect { lock }.to change { entity.locked_jids }.to([job_id])
       del
-      expect(keys).not_to match_array([key.digest, key.locked, key.info, key.changelog, key.digests])
+      expect(keys).not_to contain_exactly(key.digest, key.locked, key.info, key.changelog, key.digests)
     end
   end
 
@@ -90,7 +90,7 @@ RSpec.describe SidekiqUniqueJobs::Lock do
     subject(:changelogs) { entity.changelogs }
 
     context "when no changelogs exist" do
-      it { is_expected.to match_array([]) }
+      it { is_expected.to eq([]) }
     end
 
     context "when changelogs exist" do
@@ -115,7 +115,7 @@ RSpec.describe SidekiqUniqueJobs::Lock do
         }
       end
 
-      it { is_expected.to match_array([locked_entry, queued_entry]) }
+      it { is_expected.to contain_exactly(locked_entry, queued_entry) }
     end
   end
 end

--- a/spec/sidekiq_unique_jobs/lua/lock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/lock_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "lock.lua" do
       expect(primed.count).to eq(0)
 
       expect(locked.count).to eq(1)
-      expect(locked.entries).to match_array([job_id_one])
+      expect(locked.entries).to contain_exactly(job_id_one)
       expect(locked[job_id_one].to_f).to be_within(0.5).of(now_f)
     end
   end
@@ -176,7 +176,7 @@ RSpec.describe "lock.lua" do
       expect(primed.count).to eq(0)
 
       expect(locked.count).to eq(1)
-      expect(locked.entries).to match_array([job_id_one])
+      expect(locked.entries).to contain_exactly(job_id_one)
       expect(locked[job_id_one].to_f).to be_within(0.5).of(now_f)
     end
   end
@@ -197,7 +197,7 @@ RSpec.describe "lock.lua" do
       expect(primed.count).to eq(0)
 
       expect(locked.count).to eq(1)
-      expect(locked.entries).to match_array([job_id_one])
+      expect(locked.entries).to contain_exactly(job_id_one)
       expect(locked[job_id_one].to_f).to be_within(0.5).of(now_f)
     end
   end
@@ -220,7 +220,7 @@ RSpec.describe "lock.lua" do
         expect(primed.count).to eq(0)
 
         expect(locked.count).to eq(1)
-        expect(locked.entries).to match_array([job_id_two])
+        expect(locked.entries).to contain_exactly(job_id_two)
         expect(locked[job_id_two].to_f).to be_within(0.5).of(now_f)
       end
     end
@@ -247,7 +247,7 @@ RSpec.describe "lock.lua" do
         expect(primed.count).to eq(0)
 
         expect(locked.count).to eq(2)
-        expect(locked.entries).to match_array([job_id_two, job_id_one])
+        expect(locked.entries).to contain_exactly(job_id_two, job_id_one)
         expect(locked[job_id_two].to_f).to be_within(0.5).of(now_f)
         expect(locked[job_id_one].to_f).to be_within(0.5).of(now_f)
       end
@@ -272,7 +272,7 @@ RSpec.describe "lock.lua" do
       expect(primed.count).to eq(0)
 
       expect(locked.count).to eq(1)
-      expect(locked.entries).to match_array([job_id_one])
+      expect(locked.entries).to contain_exactly(job_id_one)
       expect(locked[job_id_one].to_f).to be_within(0.5).of(now_f)
     end
   end

--- a/spec/sidekiq_unique_jobs/lua/queue_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/queue_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "queue.lua" do
         expect(get(key.digest)).to eq(job_id_two)
         expect(pttl(key.digest)).to eq(-1) # key exists without pttl
         expect(llen(key.queued)).to eq(1)
-        expect(lrange(key.queued, 0, -1)).to match_array([job_id_two])
+        expect(lrange(key.queued, 0, -1)).to contain_exactly(job_id_two)
         expect(rpop(key.queued)).to eq(job_id_two)
         expect(exists(key.primed)).to be(false)
         expect(exists(key.locked)).to be(false)
@@ -84,7 +84,7 @@ RSpec.describe "queue.lua" do
         expect(get(key.digest)).to eq(job_id_one)
         expect(pttl(key.digest)).to eq(-1) # key exists without pttl
         expect(llen(key.queued)).to eq(2)
-        expect(lrange(key.queued, 0, -1)).to match_array([job_id_two, job_id_one])
+        expect(lrange(key.queued, 0, -1)).to contain_exactly(job_id_two, job_id_one)
         expect(rpop(key.queued)).to eq(job_id_two)
         expect(exists(key.primed)).to be(false)
         expect(exists(key.locked)).to be(false)
@@ -104,7 +104,7 @@ RSpec.describe "queue.lua" do
       expect(get(key.digest)).to eq(job_id_one)
       expect(pttl(key.digest)).to eq(-1) # key exists without pttl
       expect(llen(key.queued)).to eq(1)
-      expect(lrange(key.queued, 0, -1)).to match_array([job_id_one])
+      expect(lrange(key.queued, 0, -1)).to contain_exactly(job_id_one)
       expect(rpop(key.queued)).to eq(job_id_one)
       expect(exists(key.primed)).to be(false)
       expect(exists(key.locked)).to be(false)
@@ -141,7 +141,7 @@ RSpec.describe "queue.lua" do
         expect(queue).to eq(job_id_one)
         expect(get(key.digest)).to eq(job_id_one)
         expect(llen(key.queued)).to eq(1) # There should be no keys available to be locked
-        expect(lrange(key.queued, 0, -1)).to match_array([job_id_one])
+        expect(lrange(key.queued, 0, -1)).to contain_exactly(job_id_one)
         expect(llen(key.primed)).to eq(0)
         expect(exists(key.locked)).to be(true)
         expect(hexists(key.locked, job_id_two)).to be(1)

--- a/spec/sidekiq_unique_jobs/lua/reap_orphans_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/reap_orphans_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "reap_orphans.lua" do
     context "without scheduled job" do
       it "keeps the digest" do
         expect { reap_orphans }.to change { digests.count }.by(-1)
-        expect(unique_keys).to match_array([])
+        expect(unique_keys).to eq([])
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe "reap_orphans.lua" do
 
       it "keeps the digest" do
         expect { reap_orphans }.not_to change { digests.count }.from(1)
-        expect(unique_keys).not_to match_array([])
+        expect(unique_keys).not_to eq([])
       end
     end
   end
@@ -81,7 +81,7 @@ RSpec.describe "reap_orphans.lua" do
     context "without job in retry" do
       it "keeps the digest" do
         expect { reap_orphans }.to change { digests.count }.by(-1)
-        expect(unique_keys).to match_array([])
+        expect(unique_keys).to eq([])
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe "reap_orphans.lua" do
 
       it "keeps the digest" do
         expect { reap_orphans }.not_to change { digests.count }.from(1)
-        expect(unique_keys).not_to match_array([])
+        expect(unique_keys).not_to eq([])
       end
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe "reap_orphans.lua" do
     context "without enqueued job" do
       it "keeps the digest" do
         expect { reap_orphans }.to change { digests.count }.by(-1)
-        expect(unique_keys).to match_array([])
+        expect(unique_keys).to eq([])
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe "reap_orphans.lua" do
 
       it "keeps the digest" do
         expect { reap_orphans }.not_to change { digests.count }.from(1)
-        expect(unique_keys).not_to match_array([])
+        expect(unique_keys).not_to eq([])
       end
     end
   end
@@ -117,7 +117,7 @@ RSpec.describe "reap_orphans.lua" do
     context "without job" do
       it "keeps the digest" do
         expect { reap_orphans }.to change { digests.count }.by(-1)
-        expect(unique_keys).to match_array([])
+        expect(unique_keys).to eq([])
       end
     end
 
@@ -143,7 +143,7 @@ RSpec.describe "reap_orphans.lua" do
 
       it "keeps the digest" do
         expect { reap_orphans }.not_to change { digests.count }.from(1)
-        expect(unique_keys).not_to match_array([])
+        expect(unique_keys).not_to eq([])
       end
     end
   end

--- a/spec/sidekiq_unique_jobs/lua/unlock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/unlock_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe "unlock.lua" do
         expect(primed.count).to be == 0
 
         expect(locked.count).to be == 1
-        expect(locked.entries).to match_array([job_id_two])
+        expect(locked.entries).to contain_exactly(job_id_two)
         expect(locked[job_id_two].to_f).to be_within(0.5).of(now_f)
       end
     end
@@ -187,12 +187,12 @@ RSpec.describe "unlock.lua" do
                                                         .and change { digests.count }.by(-1)
 
         expect(queued.count).to eq(1)
-        expect(queued.entries).to match_array(["1"])
+        expect(queued.entries).to contain_exactly("1")
 
         expect(primed.count).to be == 0
 
         expect(locked.count).to be == 0
-        expect(locked.entries).to match_array([])
+        expect(locked.entries).to eq([])
         expect(locked[job_id_one]).to be_nil
       end
     end

--- a/spec/sidekiq_unique_jobs/on_conflict/replace_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/replace_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
   let(:strategy)    { described_class.new(item) }
   let(:lock_digest) { "uniquejobs:a1d714a6dacd9fcfe0aa6274af3d5ab4" }
-  let(:block)       { -> { p "Hello" } } # rubocop:disable Lint/Debugger
+  let(:block)       { -> { p "Hello" } }
   let(:digest)      { digests.entries.first }
 
   let(:item) do

--- a/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
         context "without scheduled job" do
           it "deletes the digest" do
             expect { call }.to change { digests.count }.by(-1)
-            expect(unique_keys).to match_array([])
+            expect(unique_keys).to eq([])
           end
         end
 
@@ -77,7 +77,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
 
           it "keeps the digest" do
             expect { call }.not_to change { digests.count }.from(1)
-            expect(unique_keys).not_to match_array([])
+            expect(unique_keys).not_to eq([])
           end
         end
       end
@@ -88,7 +88,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
         context "without job in retry" do
           it "deletes the digest" do
             expect { call }.to change { digests.count }.by(-1)
-            expect(unique_keys).to match_array([])
+            expect(unique_keys).to eq([])
           end
         end
 
@@ -97,7 +97,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
 
           it "keeps the digest" do
             expect { call }.not_to change { digests.count }.from(1)
-            expect(unique_keys).not_to match_array([])
+            expect(unique_keys).not_to eq([])
           end
         end
       end
@@ -106,7 +106,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
         context "without enqueued job" do
           it "deletes the digest" do
             expect { call }.to change { digests.count }.by(-1)
-            expect(unique_keys).to match_array([])
+            expect(unique_keys).to eq([])
           end
         end
 
@@ -115,7 +115,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
 
           it "keeps the digest" do
             expect { call }.not_to change { digests.count }.from(1)
-            expect(unique_keys).not_to match_array([])
+            expect(unique_keys).not_to eq([])
           end
         end
       end
@@ -124,7 +124,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
         context "without job in process" do
           it "deletes the digest" do
             expect { call }.to change { digests.count }.by(-1)
-            expect(unique_keys).to match_array([])
+            expect(unique_keys).to eq([])
           end
         end
 
@@ -159,7 +159,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
 
               it "keeps the digest" do
                 expect { call }.not_to change { digests.count }.from(1)
-                expect(unique_keys).not_to match_array([])
+                expect(unique_keys).not_to eq([])
               end
             end
           end
@@ -170,7 +170,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
 
               it "keeps the digest" do
                 expect { call }.not_to change { digests.count }.from(1)
-                expect(unique_keys).not_to match_array([])
+                expect(unique_keys).not_to eq([])
               end
             end
 
@@ -179,7 +179,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
 
               it "keeps the digest" do
                 expect { call }.not_to change { digests.count }.from(1)
-                expect(unique_keys).not_to match_array([])
+                expect(unique_keys).not_to eq([])
               end
             end
           end
@@ -192,7 +192,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
 
               it "deletes the digest" do
                 expect { call }.to change { digests.count }.by(-1)
-                expect(unique_keys).to match_array([])
+                expect(unique_keys).to eq([])
               end
             end
 
@@ -201,7 +201,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
 
               it "keeps the digest" do
                 expect { call }.not_to change { digests.count }.from(1)
-                expect(unique_keys).not_to match_array([])
+                expect(unique_keys).not_to eq([])
               end
             end
           end

--- a/spec/sidekiq_unique_jobs/orphans/ruby_reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/ruby_reaper_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::RubyReaper do
       end
 
       it "does not check for orphans" do
-        expect(orphans).to match_array([])
+        expect(orphans).to eq([])
         expect(service).not_to have_received(:belongs_to_job?)
       end
     end
@@ -75,7 +75,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::RubyReaper do
         SidekiqUniqueJobs.use_config(reaper_count: 1) do
           expect(orphans.size).to eq(1)
           # This is the first one to be created and should therefor be the only match
-          expect(orphans).to match_array([digest])
+          expect(orphans).to contain_exactly(digest)
         end
       end
     end
@@ -84,13 +84,13 @@ RSpec.describe SidekiqUniqueJobs::Orphans::RubyReaper do
       let(:item) { raw_item.merge("at" => Time.now.to_f + 3_600) }
 
       context "without scheduled job" do
-        it { is_expected.to match_array([digest]) }
+        it { is_expected.to contain_exactly(digest) }
       end
 
       context "with scheduled job" do
         before { push_item(item) }
 
-        it { is_expected.to match_array([]) }
+        it { is_expected.to eq([]) }
       end
     end
 
@@ -98,25 +98,25 @@ RSpec.describe SidekiqUniqueJobs::Orphans::RubyReaper do
       let(:item) { raw_item.merge("retry_count" => 2, "failed_at" => now_f) }
 
       context "without job in retry" do
-        it { is_expected.to match_array([digest]) }
+        it { is_expected.to contain_exactly(digest) }
       end
 
       context "with job in retry" do
         before { zadd("retry", Time.now.to_f.to_s, dump_json(item)) }
 
-        it { is_expected.to match_array([]) }
+        it { is_expected.to eq([]) }
       end
     end
 
     context "when digest exists in a queue" do
       context "without enqueued job" do
-        it { is_expected.to match_array([digest]) }
+        it { is_expected.to contain_exactly(digest) }
       end
 
       context "with enqueued job" do
         before { push_item(item) }
 
-        it { is_expected.to match_array([]) }
+        it { is_expected.to eq([]) }
       end
     end
   end

--- a/spec/sidekiq_unique_jobs/redis/hash_spec.rb
+++ b/spec/sidekiq_unique_jobs/redis/hash_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SidekiqUniqueJobs::Redis::Hash do
     let(:with_values) { nil }
 
     context "without entries" do
-      it { is_expected.to match_array([]) }
+      it { is_expected.to eq([]) }
     end
 
     context "with entries" do
@@ -23,7 +23,7 @@ RSpec.describe SidekiqUniqueJobs::Redis::Hash do
       context "when with_values: false" do
         let(:with_values) { false }
 
-        it { is_expected.to match_array([job_id]) }
+        it { is_expected.to contain_exactly(job_id) }
       end
 
       context "when with_values: true" do

--- a/spec/sidekiq_unique_jobs/redis/set_spec.rb
+++ b/spec/sidekiq_unique_jobs/redis/set_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe SidekiqUniqueJobs::Redis::Set do
     subject(:entries) { entity.entries }
 
     context "without entries" do
-      it { is_expected.to match_array([]) }
+      it { is_expected.to eq([]) }
     end
 
     context "with entries" do
       before { sadd(digest, job_id) }
 
-      it { is_expected.to match_array([job_id]) }
+      it { is_expected.to contain_exactly(job_id) }
     end
   end
 

--- a/spec/sidekiq_unique_jobs/redis/sorted_set_spec.rb
+++ b/spec/sidekiq_unique_jobs/redis/sorted_set_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SidekiqUniqueJobs::Redis::SortedSet do
     subject(:entries) { entity.entries(with_scores: with_scores) }
 
     context "without entries" do
-      it { is_expected.to match_array([]) }
+      it { is_expected.to eq([]) }
     end
 
     context "with entries" do
@@ -19,7 +19,7 @@ RSpec.describe SidekiqUniqueJobs::Redis::SortedSet do
       context "when given with_scores: false" do
         let(:with_scores) { false }
 
-        it { is_expected.to match_array([job_id]) }
+        it { is_expected.to contain_exactly(job_id) }
       end
 
       context "when given with_scores: true" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ Sidekiq.configure_server do |config|
     chain.add SidekiqUniqueJobs::Middleware::Server
   end
 
-  config.error_handlers << ->(ex, ctx_hash) { p ex, ctx_hash } # rubocop:disable Lint/Debugger
+  config.error_handlers << ->(ex, ctx_hash) { p ex, ctx_hash }
   config.death_handlers << lambda do |job, _ex|
     digest = job["lock_digest"]
     SidekiqUniqueJobs::Digests.new.delete_by_digest(digest) if digest
@@ -119,7 +119,7 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) do
-    p EVENTS if ENV["REFLECT_DEBUG"] # rubocop:disable Lint/Debugger
+    p EVENTS if ENV["REFLECT_DEBUG"]
   end
 end
 


### PR DESCRIPTION
cleanup for #762 & #763

replace `match_array([])` with `eq([])` and rubocop -A run through for the rest.

only one spec had an issue with either of those other matchers - left a rubocop disable on it (digests_spec#132)