### PR TITLE
update debug_lua check to match passed in arg type

### DIFF
--- a/lib/sidekiq_unique_jobs/lua/delete.lua
+++ b/lib/sidekiq_unique_jobs/lua/delete.lua
@@ -17,7 +17,7 @@ local limit        = tonumber(ARGV[4])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = tostring(ARGV[6]) == "true"
+local debug_lua    = tostring(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 local redisversion = tostring(ARGV[9])

--- a/lib/sidekiq_unique_jobs/lua/delete_by_digest.lua
+++ b/lib/sidekiq_unique_jobs/lua/delete_by_digest.lua
@@ -12,7 +12,7 @@ local digests    = KEYS[9]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[1])
-local debug_lua    = tonumber(ARGV[2]) == "1"
+local debug_lua    = tostring(ARGV[2]) == "1"
 local max_history  = tonumber(ARGV[3])
 local script_name  = tostring(ARGV[4]) .. ".lua"
 local redisversion = tostring(ARGV[5])

--- a/lib/sidekiq_unique_jobs/lua/delete_by_digest.lua
+++ b/lib/sidekiq_unique_jobs/lua/delete_by_digest.lua
@@ -12,7 +12,7 @@ local digests    = KEYS[9]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[1])
-local debug_lua    = ARGV[2] == "true"
+local debug_lua    = tonumber(ARGV[2]) == "1"
 local max_history  = tonumber(ARGV[3])
 local script_name  = tostring(ARGV[4]) .. ".lua"
 local redisversion = tostring(ARGV[5])

--- a/lib/sidekiq_unique_jobs/lua/delete_job_by_digest.lua
+++ b/lib/sidekiq_unique_jobs/lua/delete_job_by_digest.lua
@@ -10,7 +10,7 @@ local digest       = ARGV[1]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[2])
-local debug_lua    = tonumber(ARGV[3]) == "1"
+local debug_lua    = tostring(ARGV[3]) == "1"
 local max_history  = tonumber(ARGV[4])
 local script_name  = tostring(ARGV[5]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/delete_job_by_digest.lua
+++ b/lib/sidekiq_unique_jobs/lua/delete_job_by_digest.lua
@@ -10,7 +10,7 @@ local digest       = ARGV[1]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[2])
-local debug_lua    = ARGV[3] == "true"
+local debug_lua    = tonumber(ARGV[3]) == "1"
 local max_history  = tonumber(ARGV[4])
 local script_name  = tostring(ARGV[5]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/find_digest_in_queues.lua
+++ b/lib/sidekiq_unique_jobs/lua/find_digest_in_queues.lua
@@ -4,7 +4,7 @@ local digest = KEYS[1]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[2])
-local debug_lua    = ARGV[3] == "true"
+local debug_lua    = tonumber(ARGV[3]) == "1"
 local max_history  = tonumber(ARGV[4])
 local script_name  = tostring(ARGV[5]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/find_digest_in_queues.lua
+++ b/lib/sidekiq_unique_jobs/lua/find_digest_in_queues.lua
@@ -4,7 +4,7 @@ local digest = KEYS[1]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[2])
-local debug_lua    = tonumber(ARGV[3]) == "1"
+local debug_lua    = tostring(ARGV[3]) == "1"
 local max_history  = tonumber(ARGV[4])
 local script_name  = tostring(ARGV[5]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/lock.lua
+++ b/lib/sidekiq_unique_jobs/lua/lock.lua
@@ -20,7 +20,7 @@ local limit        = tonumber(ARGV[4])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = tonumber(ARGV[6]) == "1"
+local debug_lua    = tostring(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 local redisversion = ARGV[9]

--- a/lib/sidekiq_unique_jobs/lua/lock.lua
+++ b/lib/sidekiq_unique_jobs/lua/lock.lua
@@ -20,7 +20,7 @@ local limit        = tonumber(ARGV[4])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = ARGV[6] == "true"
+local debug_lua    = tonumber(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 local redisversion = ARGV[9]

--- a/lib/sidekiq_unique_jobs/lua/lock_until_expired.lua
+++ b/lib/sidekiq_unique_jobs/lua/lock_until_expired.lua
@@ -20,7 +20,7 @@ local limit        = tonumber(ARGV[4])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = tonumber(ARGV[6]) == "1"
+local debug_lua    = tostring(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 local redisversion = ARGV[9]

--- a/lib/sidekiq_unique_jobs/lua/lock_until_expired.lua
+++ b/lib/sidekiq_unique_jobs/lua/lock_until_expired.lua
@@ -20,7 +20,7 @@ local limit        = tonumber(ARGV[4])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = ARGV[6] == "true"
+local debug_lua    = tonumber(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 local redisversion = ARGV[9]

--- a/lib/sidekiq_unique_jobs/lua/locked.lua
+++ b/lib/sidekiq_unique_jobs/lua/locked.lua
@@ -14,7 +14,7 @@ local job_id = ARGV[1]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[2])
-local debug_lua    = ARGV[3] == "true"
+local debug_lua    = tonumber(ARGV[3]) == "1"
 local max_history  = tonumber(ARGV[4])
 local script_name  = tostring(ARGV[5]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/locked.lua
+++ b/lib/sidekiq_unique_jobs/lua/locked.lua
@@ -14,7 +14,7 @@ local job_id = ARGV[1]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[2])
-local debug_lua    = tonumber(ARGV[3]) == "1"
+local debug_lua    = tostring(ARGV[3]) == "1"
 local max_history  = tonumber(ARGV[4])
 local script_name  = tostring(ARGV[5]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/queue.lua
+++ b/lib/sidekiq_unique_jobs/lua/queue.lua
@@ -19,7 +19,7 @@ local limit     = tonumber(ARGV[4])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = ARGV[6] == "true"
+local debug_lua    = tonumber(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/queue.lua
+++ b/lib/sidekiq_unique_jobs/lua/queue.lua
@@ -19,7 +19,7 @@ local limit     = tonumber(ARGV[4])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = tonumber(ARGV[6]) == "1"
+local debug_lua    = tostring(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/reap_orphans.lua
+++ b/lib/sidekiq_unique_jobs/lua/reap_orphans.lua
@@ -14,7 +14,7 @@ local threshold    = tonumber(ARGV[2])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[3])
-local debug_lua    = tonumber(ARGV[4]) == "1"
+local debug_lua    = tostring(ARGV[4]) == "1"
 local max_history  = tonumber(ARGV[5])
 local script_name  = ARGV[6] .. ".lua"
 local redisversion = ARGV[7]

--- a/lib/sidekiq_unique_jobs/lua/reap_orphans.lua
+++ b/lib/sidekiq_unique_jobs/lua/reap_orphans.lua
@@ -14,7 +14,7 @@ local threshold    = tonumber(ARGV[2])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[3])
-local debug_lua    = ARGV[4] == "true"
+local debug_lua    = tonumber(ARGV[4]) == "1"
 local max_history  = tonumber(ARGV[5])
 local script_name  = ARGV[6] .. ".lua"
 local redisversion = ARGV[7]

--- a/lib/sidekiq_unique_jobs/lua/shared/_common.lua
+++ b/lib/sidekiq_unique_jobs/lua/shared/_common.lua
@@ -9,11 +9,6 @@ local function toversion(version)
   }
 end
 
-local function toboolean(val)
-  val = tostring(val)
-  return val == "1" or val == "true"
-end
-
 local function log_debug( ... )
   if debug_lua ~= true then return end
 

--- a/lib/sidekiq_unique_jobs/lua/unlock.lua
+++ b/lib/sidekiq_unique_jobs/lua/unlock.lua
@@ -19,7 +19,7 @@ local limit     = tonumber(ARGV[4])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = tonumber(ARGV[6]) == "1"
+local debug_lua    = tostring(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 local redisversion = ARGV[9]

--- a/lib/sidekiq_unique_jobs/lua/unlock.lua
+++ b/lib/sidekiq_unique_jobs/lua/unlock.lua
@@ -19,7 +19,7 @@ local limit     = tonumber(ARGV[4])
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = ARGV[6] == "true"
+local debug_lua    = tonumber(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 local redisversion = ARGV[9]

--- a/lib/sidekiq_unique_jobs/lua/update_version.lua
+++ b/lib/sidekiq_unique_jobs/lua/update_version.lua
@@ -9,7 +9,7 @@ local version  = ARGV[1]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[2])
-local debug_lua    = tonumber(ARGV[3]) == "1"
+local debug_lua    = tostring(ARGV[3]) == "1"
 local max_history  = tonumber(ARGV[4])
 local script_name  = tostring(ARGV[5]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/update_version.lua
+++ b/lib/sidekiq_unique_jobs/lua/update_version.lua
@@ -9,7 +9,7 @@ local version  = ARGV[1]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[2])
-local debug_lua    = ARGV[3] == "true"
+local debug_lua    = tonumber(ARGV[3]) == "1"
 local max_history  = tonumber(ARGV[4])
 local script_name  = tostring(ARGV[5]) .. ".lua"
 ---------  END injected arguments ---------

--- a/lib/sidekiq_unique_jobs/lua/upgrade.lua
+++ b/lib/sidekiq_unique_jobs/lua/upgrade.lua
@@ -6,7 +6,7 @@ local dead_version = KEYS[2]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = tonumber(ARGV[6]) == "1"
+local debug_lua    = tostring(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 local redisversion = ARGV[9]

--- a/lib/sidekiq_unique_jobs/lua/upgrade.lua
+++ b/lib/sidekiq_unique_jobs/lua/upgrade.lua
@@ -6,7 +6,7 @@ local dead_version = KEYS[2]
 
 --------  BEGIN injected arguments --------
 local current_time = tonumber(ARGV[5])
-local debug_lua    = ARGV[6] == "true"
+local debug_lua    = tonumber(ARGV[6]) == "1"
 local max_history  = tonumber(ARGV[7])
 local script_name  = tostring(ARGV[8]) .. ".lua"
 local redisversion = ARGV[9]


### PR DESCRIPTION
I believe this was introduced with `SidekiqUniqueJobs::Script::Caller::normalize_argv`

The lua scripts check for a value of `"true"` for `debug_lua` but `normalize_arg` changes that to integer 1 that looks to be typed to a string when it gets to the lua script (I don't know lua in any way so this could very well be wrong)

```
def normalize_argv(argv)
  argv.each_with_index do |item, index|
    case item
    when FalseClass, NilClass
      argv[index] = 0
    when TrueClass
      argv[index] = 1
    end
  end
end
```

also remove unused `toboolean` in lua scripts

I have no idea how to add a test for this.