### PR TITLE
fix(locksmith): replace deprecated rpoplpush w/lmove

### DIFF
--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -312,7 +312,7 @@ module SidekiqUniqueJobs
     # @api private
     #
     def rpoplpush(conn)
-      conn.rpoplpush(key.queued, key.primed)
+      conn.lmove(key.queued, key.primed, "RIGHT", "LEFT")
     end
 
     #

--- a/spec/support/sidekiq_unique_jobs/testing.rb
+++ b/spec/support/sidekiq_unique_jobs/testing.rb
@@ -328,7 +328,7 @@ module SidekiqUniqueJobs
       end
 
       def rpoplpush(source, destination)
-        redis { |conn| conn.rpoplpush(source, destination) }
+        redis { |conn| conn.lmove(source, destination, "RIGHT", "LEFT") }
       end
 
       def blpop(*args)


### PR DESCRIPTION
This PR replaces the occurrences of `rpoplpush` by `lmove` since the first one has been deprecated in Redis 6.2: https://redis.io/commands/rpoplpush/