### PR TITLE
Fix rubocop failure by expecting array to be empty

### DIFF
--- a/spec/sidekiq_unique_jobs/digests_spec.rb
+++ b/spec/sidekiq_unique_jobs/digests_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe SidekiqUniqueJobs::Digests do
 
     it "deletes all matching digests" do
       expect(delete_by_pattern).to be_a(Integer)
-      expect(digests.entries).to match_array([]) # rubocop:todo RSpec/MatchArray
+      expect(digests.entries).to be_empty
     end
 
     it "logs performance info" do


### PR DESCRIPTION
This PR fixes the 2 failures that is happening on rubocop