### PR TITLE
fix: `while_executing` should not invoke conflict strategy when the job was successfully executed.

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/while_executing.rb
@@ -42,6 +42,7 @@ module SidekiqUniqueJobs
         with_logging_context do
           executed = locksmith.execute do
             yield
+            item[JID]
           ensure
             unlock_and_callback
           end

--- a/spec/sidekiq_unique_jobs/lock/while_executing_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/while_executing_spec.rb
@@ -91,10 +91,12 @@ RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting do
 
       it "reflects execution_failed" do
         process_one.execute do
-          process_two.execute { puts "BOGUS!" }
-          # NOTE: Below looks weird but tests that
-          #   the result from process_two (which is nil) isn't considered.
-          jid_one
+          process_two.execute {
+            puts "BOGUS!"
+            nil
+          }
+
+          nil
         end
 
         expect(process_one).not_to have_received(:reflect).with(:execution_failed, item_one)

--- a/spec/sidekiq_unique_jobs/lock/while_executing_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/while_executing_spec.rb
@@ -91,10 +91,10 @@ RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting do
 
       it "reflects execution_failed" do
         process_one.execute do
-          process_two.execute {
+          process_two.execute do
             puts "BOGUS!"
             nil
-          }
+          end
 
           nil
         end

--- a/spec/sidekiq_unique_jobs/on_conflict/reject_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/reject_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reject do
   end
 
   before do
-    allow(strategy).to receive(:deadset).and_return(deadset)
-    allow(strategy).to receive(:payload).and_return(payload)
+    allow(strategy).to receive_messages(deadset: deadset, payload: payload)
   end
 
   describe "#replace?" do

--- a/spec/sidekiq_unique_jobs/on_conflict/replace_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/replace_spec.rb
@@ -33,9 +33,8 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
       let(:jid) { "bogus" }
 
       before do
-        allow(strategy).to receive(:delete_job_by_digest).and_return(jid)
+        allow(strategy).to receive_messages(delete_job_by_digest: jid, delete_lock: 9)
         allow(strategy).to receive(:log_info).and_call_original
-        allow(strategy).to receive(:delete_lock).and_return(9)
       end
 
       it "logs important information" do
@@ -50,9 +49,8 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
       let(:jid) { "bogus" }
 
       before do
-        allow(strategy).to receive(:delete_job_by_digest).and_return(jid)
+        allow(strategy).to receive_messages(delete_job_by_digest: jid, delete_lock: nil)
         allow(strategy).to receive(:log_info).and_call_original
-        allow(strategy).to receive(:delete_lock).and_return(nil)
       end
 
       it "logs important information" do
@@ -68,9 +66,8 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Replace do
       let(:block) { nil }
 
       before do
-        allow(strategy).to receive(:delete_job_by_digest).and_return(jid)
+        allow(strategy).to receive_messages(delete_job_by_digest: jid, delete_lock: nil)
         allow(strategy).to receive(:log_info).and_call_original
-        allow(strategy).to receive(:delete_lock).and_return(nil)
       end
 
       it "does not call block" do

--- a/spec/sidekiq_unique_jobs/orphans/manager_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/manager_spec.rb
@@ -16,11 +16,9 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Manager do
     before do
       allow(SidekiqUniqueJobs::Orphans::Observer).to receive(:new).and_return(observer)
 
-      allow(described_class).to receive(:task).and_return(task)
+      allow(described_class).to receive_messages(task: task, log_info: nil)
       allow(task).to receive(:add_observer).with(observer)
       allow(task).to receive(:execute)
-
-      allow(described_class).to receive(:log_info).and_return(nil)
     end
 
     context "when registered?" do
@@ -72,11 +70,9 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Manager do
     before do
       allow(SidekiqUniqueJobs::Orphans::Observer).to receive(:new).and_return(observer)
 
-      allow(described_class).to receive(:task).and_return(task)
+      allow(described_class).to receive_messages(task: task, log_info: nil)
       allow(task).to receive(:add_observer).with(observer)
       allow(task).to receive(:execute)
-
-      allow(described_class).to receive(:log_info).and_return(nil)
     end
 
     context "when unregistered?" do

--- a/spec/sidekiq_unique_jobs/orphans/reaper_resurrector_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/reaper_resurrector_spec.rb
@@ -16,10 +16,8 @@ RSpec.describe SidekiqUniqueJobs::Orphans::ReaperResurrector do
     end
 
     before do
-      allow(described_class).to receive(:task).and_return(task)
+      allow(described_class).to receive_messages(task: task, log_info: nil)
       allow(task).to receive(:execute)
-
-      allow(described_class).to receive(:log_info).and_return(nil)
     end
 
     context "when resurrector is disabled" do

--- a/spec/support/shared_examples/an_executing_lock_with_error_handling.rb
+++ b/spec/support/shared_examples/an_executing_lock_with_error_handling.rb
@@ -10,8 +10,7 @@ RSpec.shared_examples "an executing lock with error handling" do
 
   before do
     allow(lock).to receive(:locked?).and_return(initially_locked?, locked?)
-    allow(lock).to receive(:unlock).and_return(true)
-    allow(lock).to receive(:delete).and_return(true)
+    allow(lock).to receive_messages(unlock: true, delete: true)
     allow(callback).to receive(:call).and_call_original
     allow(block).to receive(:call).and_call_original
     allow(lock).to receive(:log_warn)


### PR DESCRIPTION
Currently, the `WhileExecuting` lock only works properly if the middleware chain downstream returns a truthy value.

When a falsey value is returned, the on-conflict strategy is invoked, which shouldn't happen.

Originally reported [here](https://github.com/mhenrixon/sidekiq-unique-jobs/issues/800).
