### PR TITLE
Handle strategy fallbacks properly

### DIFF
--- a/lib/sidekiq_unique_jobs/lock_config.rb
+++ b/lib/sidekiq_unique_jobs/lock_config.rb
@@ -113,14 +113,20 @@ module SidekiqUniqueJobs
 
     # the strategy to use as conflict resolution from sidekiq client
     def on_client_conflict
-      @on_client_conflict ||= on_conflict["client"] || on_conflict[:client] if on_conflict.is_a?(Hash)
-      @on_client_conflict ||= on_conflict
+      if on_conflict.is_a?(Hash)
+        @on_client_conflict ||= on_conflict["client"] || on_conflict[:client]
+      else
+        @on_client_conflict ||= on_conflict
+      end
     end
 
     # the strategy to use as conflict resolution from sidekiq server
     def on_server_conflict
-      @on_server_conflict ||= on_conflict["server"] || on_conflict[:server] if on_conflict.is_a?(Hash)
-      @on_server_conflict ||= on_conflict
+      if on_conflict.is_a?(Hash)
+        @on_server_conflict ||= on_conflict["server"] || on_conflict[:server]
+      else
+        @on_server_conflict ||= on_conflict
+      end
     end
   end
 end

--- a/spec/sidekiq_unique_jobs/lock_config_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_config_spec.rb
@@ -146,6 +146,12 @@ RSpec.describe SidekiqUniqueJobs::LockConfig do
 
       it { is_expected.to eq(:replace) }
     end
+
+    context "when on_conflict is defined only for server" do
+      let(:on_conflict) { {server: :log}}
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe "#on_server_conflict" do
@@ -157,6 +163,12 @@ RSpec.describe SidekiqUniqueJobs::LockConfig do
       let(:on_conflict) { { client: :replace, server: :reschedule } }
 
       it { is_expected.to eq(:reschedule) }
+    end
+
+    context "when on_conflict is defined only for client" do
+      let(:on_conflict) { {client: :log}}
+
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
Hi, first time contributor here - without "proper" ruby background - so please advise if these few lines could be written in a more idiomatic way.

---

If strategy was set for server and not for client in a hash - that would lead to on_client_conflict to return a hash back. Which would in turn lead to [an error in on_conflict#find_strategy](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/main/lib/sidekiq_unique_jobs/on_conflict.rb#L34) because it cannot send a message to `to_sym` on a hash.

We've observed this issue where we've set an `on conflict` strategy for server on `UntilExecuted` which seems to do a [client-only on conflict resolution](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/main/lib/sidekiq_unique_jobs/lock/until_executed.rb#L23). So most likely our job is not set properly - however I want to check with you whether that could be handled differently without throwing errors.

---

If we decide to merge this PR - would it be possible to also backport it to v7.x.x?
