### PR TITLE
fix: `while_executing` should not invoke conflict strategy when the job was successfully executed [v8]

### DIFF
--- a/lib/sidekiq_unique_jobs/lock/while_executing.rb
+++ b/lib/sidekiq_unique_jobs/lock/while_executing.rb
@@ -42,6 +42,7 @@ module SidekiqUniqueJobs
         with_logging_context do
           executed = locksmith.execute do
             yield
+            item[JID]
           ensure
             unlock_and_callback
           end

--- a/spec/sidekiq_unique_jobs/lock/while_executing_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock/while_executing_spec.rb
@@ -91,10 +91,12 @@ RSpec.describe SidekiqUniqueJobs::Lock::WhileExecuting do
 
       it "reflects execution_failed" do
         process_one.execute do
-          process_two.execute { puts "BOGUS!" }
-          # NOTE: Below looks weird but tests that
-          #   the result from process_two (which is nil) isn't considered.
-          jid_one
+          process_two.execute do
+            puts "BOGUS!"
+            nil
+          end
+
+          nil
         end
 
         expect(process_one).not_to have_received(:reflect).with(:execution_failed, item_one)


### PR DESCRIPTION
For context, I didn't find any PR fixing it to the 8 version, we are not updating the gem to v8.0.3 because of this error. I found the solution for the v7.1 here https://github.com/mhenrixon/sidekiq-unique-jobs/pull/806 and only replicated it. So if it works, all the credits go to @leandrogoe.

Let me know if it is something useful or if I missed something, but as far as I can see, we didn't open a PR fixing it to v8+, right?

It should fix the https://github.com/mhenrixon/sidekiq-unique-jobs/issues/800