### PR TITLE
Add sidekiq_option for on-conflict-reschedule perform_in time

### DIFF
--- a/lib/sidekiq_unique_jobs/on_conflict/reschedule.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/reschedule.rb
@@ -21,7 +21,7 @@ module SidekiqUniqueJobs
       #   This will mess up sidekiq stats because a new job is created
       def call
         if sidekiq_job_class?
-          if job_class.set(queue: item["queue"].to_sym).perform_in(5, *item[ARGS])
+          if job_class.set(queue: item["queue"].to_sym).perform_in(schedule_in, *item[ARGS])
             reflect(:rescheduled, item)
           else
             reflect(:reschedule_failed, item)
@@ -29,6 +29,10 @@ module SidekiqUniqueJobs
         else
           reflect(:unknown_sidekiq_worker, item)
         end
+      end
+
+      def schedule_in
+        job_class.get_sidekiq_options["schedule_in"] || 5
       end
     end
   end

--- a/spec/sidekiq_unique_jobs/on_conflict/reschedule_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/reschedule_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reschedule do
         allow(UniqueJobOnConflictReschedule).to receive(:perform_in).and_call_original
       end
 
+      context "when schedule_in is set to ten seconds" do
+        around do |block|
+          UniqueJobOnConflictReschedule.use_options(schedule_in: 10) do
+            block.call
+          end
+        end
+
+        it "schedules a job ten seconds from now" do
+          expect { call }.to change { schedule_count }.by(1)
+
+          expect(UniqueJobOnConflictReschedule).to have_received(:perform_in)
+            .with(10, *item["args"])
+        end
+      end
+
       it "schedules a job five seconds from now" do
         expect { call }.to change { schedule_count }.by(1)
 


### PR DESCRIPTION
Add schedule_in sidekiq job option to customize the on-conflict-reschedule duration of 5 seconds. The default remains 5 seconds if no schedule_in is provided.

In my particular use-case for on-conflict-reschedule, the jobs that I'm rescheduling have rather long processing times (eg minutes instead of seconds). The default `perform_in` of 5 seconds causes a lot of churn in the sidekiq scheduler, I'd prefer to schedule conflicts out another minute or so rather than attempting after a few seconds.