### PR TITLE
fix: Sidekiq 7.2 throws TypeError: Unsupported command argument type: TrueClass when using byscore: true 

### DIFF
--- a/lib/sidekiq_unique_jobs/orphans/manager.rb
+++ b/lib/sidekiq_unique_jobs/orphans/manager.rb
@@ -192,7 +192,7 @@ module SidekiqUniqueJobs
       # @return [void]
       #
       def register_reaper_process
-        redis { |conn| conn.set(UNIQUE_REAPER, current_timestamp, nx: true, ex: drift_reaper_interval) }
+        redis { |conn| conn.set(UNIQUE_REAPER, current_timestamp, "nx", "ex", drift_reaper_interval) }
       end
 
       #
@@ -202,7 +202,7 @@ module SidekiqUniqueJobs
       # @return [void]
       #
       def refresh_reaper_mutex
-        redis { |conn| conn.set(UNIQUE_REAPER, current_timestamp, ex: drift_reaper_interval) }
+        redis { |conn| conn.set(UNIQUE_REAPER, current_timestamp, "ex", drift_reaper_interval) }
       end
 
       #

--- a/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
+++ b/lib/sidekiq_unique_jobs/orphans/ruby_reaper.rb
@@ -79,7 +79,7 @@ module SidekiqUniqueJobs
       def expired_digests
         max_score = (start_time - reaper_timeout).to_f
 
-        conn.zrange(EXPIRING_DIGESTS, 0, max_score, byscore: true)
+        conn.zrange(EXPIRING_DIGESTS, 0, max_score, "byscore")
       end
 
       #

--- a/lib/sidekiq_unique_jobs/redis/sorted_set.rb
+++ b/lib/sidekiq_unique_jobs/redis/sorted_set.rb
@@ -24,10 +24,11 @@ module SidekiqUniqueJobs
       # @return [Hash] when given with_scores: true
       #
       def entries(with_scores: true)
-        entrys = redis { |conn| conn.zrange(key, 0, -1, withscores: with_scores) }
-        return entrys unless with_scores
+        return redis { |conn| conn.zrange(key, 0, -1) } unless with_scores
 
-        entrys.each_with_object({}) { |pair, hash| hash[pair[0]] = pair[1] }
+        redis { |conn| conn.zrange(key, 0, -1, "withscores") }.each_with_object({}) do |pair, hash|
+          hash[pair[0]] = pair[1]
+        end
       end
 
       #

--- a/spec/performance/lock_digest_spec.rb
+++ b/spec/performance/lock_digest_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe SidekiqUniqueJobs::LockDigest, perf: true do
+# rubocop:disable RSpec/SpecFilePathFormat, RSpec/FilePath
+RSpec.describe SidekiqUniqueJobs::LockDigest, :perf do
   let(:lock_digest)  { described_class.new(item) }
   let(:job_class)    { UntilExecutedJob }
   let(:class_name)   { worker_class.to_s }
@@ -50,3 +51,4 @@ RSpec.describe SidekiqUniqueJobs::LockDigest, perf: true do
     end
   end
 end
+# rubocop:enable RSpec/SpecFilePathFormat, RSpec/FilePath

--- a/spec/performance/locksmith_spec.rb
+++ b/spec/performance/locksmith_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe SidekiqUniqueJobs::Locksmith, perf: true do
+# rubocop:disable RSpec/SpecFilePathFormat, RSpec/FilePath
+RSpec.describe SidekiqUniqueJobs::Locksmith, :perf do
   let(:locksmith_one)   { described_class.new(item_one) }
   let(:locksmith_two)   { described_class.new(item_two) }
 
@@ -49,3 +50,4 @@ RSpec.describe SidekiqUniqueJobs::Locksmith, perf: true do
     expect { locksmith_one.lock {} }.to perform_allocation(Array => 12_640, Hash => 13_888).bytes
   end
 end
+# rubocop:enable RSpec/SpecFilePathFormat, RSpec/FilePath

--- a/spec/sidekiq_unique_jobs/changelog_spec.rb
+++ b/spec/sidekiq_unique_jobs/changelog_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
 
     it "adds a new entry" do
       expect { add }.to change { entity.entries.size }.by(1)
-      expect(add).to be == 1
+      expect(add).to eq 1
     end
   end
 
@@ -39,14 +39,14 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
 
       it "clears out all entries" do
         expect { clear }.to change { entity.entries.size }.by(-1)
-        expect(clear).to be == 1
+        expect(clear).to eq 1
       end
     end
 
     context "without entries" do
       it "returns 0 (zero)" do
         expect { clear }.not_to change { entity.entries.size }
-        expect(clear).to be == 0
+        expect(clear).to eq 0
       end
     end
   end
@@ -55,13 +55,13 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
     subject(:exist?) { entity.exist? }
 
     context "when no entries exist" do
-      it { is_expected.to be == false }
+      it { is_expected.to be false }
     end
 
     context "when entries exist" do
       before { simulate_lock(key, job_id) }
 
-      it { is_expected.to be == true }
+      it { is_expected.to be true }
     end
   end
 
@@ -69,13 +69,13 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
     subject(:pttl) { entity.pttl }
 
     context "when no entries exist" do
-      it { is_expected.to be == -2 }
+      it { is_expected.to eq(-2) }
     end
 
     context "when entries exist without expiration" do
       before { simulate_lock(key, job_id) }
 
-      it { is_expected.to be == -1 }
+      it { is_expected.to eq(-1) }
     end
 
     context "when entries exist with expiration" do
@@ -92,13 +92,13 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
     subject(:ttl) { entity.ttl }
 
     context "when no entries exist" do
-      it { is_expected.to be == -2 }
+      it { is_expected.to eq(-2) }
     end
 
     context "when entries exist without expiration" do
       before { simulate_lock(key, job_id) }
 
-      it { is_expected.to be == -1 }
+      it { is_expected.to eq(-1) }
     end
 
     context "when entries exist with expiration" do
@@ -107,7 +107,7 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
         expire(key.changelog, 600)
       end
 
-      it { is_expected.to be == 600 }
+      it { is_expected.to eq 600 }
     end
   end
 
@@ -115,7 +115,7 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
     subject(:expires?) { entity.expires? }
 
     context "when no entries exist" do
-      it { is_expected.to be == false }
+      it { is_expected.to be false }
     end
 
     context "when entries exist" do
@@ -124,7 +124,7 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
         expire(key.changelog, 600)
       end
 
-      it { is_expected.to be == true }
+      it { is_expected.to be true }
     end
   end
 
@@ -132,13 +132,13 @@ RSpec.describe SidekiqUniqueJobs::Changelog do
     subject(:count) { entity.count }
 
     context "when no entries exist" do
-      it { is_expected.to be == 0 }
+      it { is_expected.to eq 0 }
     end
 
     context "when entries exist" do
       before { simulate_lock(key, job_id) }
 
-      it { is_expected.to be == 2 }
+      it { is_expected.to eq 2 }
     end
   end
 

--- a/spec/sidekiq_unique_jobs/cli_spec.rb
+++ b/spec/sidekiq_unique_jobs/cli_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe SidekiqUniqueJobs::Cli, ruby_ver: ">= 2.5" do
             jobs  del PATTERN
 
           Options:
-            d, [--dry-run], [--no-dry-run]  # set to false to perform deletion
-            c, [--count=N]                  # The max number of digests to return
-                                            # Default: 1000
+            -d, [--dry-run], [--no-dry-run]  # set to false to perform deletion
+            -c, [--count=N]                  # The max number of digests to return
+                                             # Default: 1000
 
           deletes unique digests from redis by pattern
         HEADER
@@ -55,8 +55,8 @@ RSpec.describe SidekiqUniqueJobs::Cli, ruby_ver: ">= 2.5" do
             jobs  list PATTERN
 
           Options:
-            c, [--count=N]  # The max number of digests to return
-                            # Default: 1000
+            -c, [--count=N]  # The max number of digests to return
+                             # Default: 1000
 
           list all unique digests and their expiry time
         HEADER

--- a/spec/sidekiq_unique_jobs/configuration_spec.rb
+++ b/spec/sidekiq_unique_jobs/configuration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
+# rubocop:disable RSpec/SpecFilePathFormat, RSpec/FilePath
 RSpec.describe SidekiqUniqueJobs do
   describe "define custom lock strategies" do
     subject(:middleware_call) do
@@ -65,4 +65,4 @@ RSpec.describe SidekiqUniqueJobs do
     end
   end
 end
-# rubocop:enable RSpec/FilePath
+# rubocop:enable RSpec/SpecFilePathFormat, RSpec/FilePath

--- a/spec/sidekiq_unique_jobs/lua/delete_by_digest_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/delete_by_digest_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe "delete_by_digest.lua" do
   it "deletes the expected keys from redis" do
     expect(delete_by_digest).to eq(8)
 
-    expect(queued.count).to be == 0
-    expect(primed.count).to be == 0
-    expect(locked.count).to be == 0
+    expect(queued.count).to eq 0
+    expect(primed.count).to eq 0
+    expect(locked.count).to eq 0
 
-    expect(run_queued.count).to be == 0
-    expect(run_primed.count).to be == 0
-    expect(run_locked.count).to be == 0
+    expect(run_queued.count).to eq 0
+    expect(run_primed.count).to eq 0
+    expect(run_locked.count).to eq 0
   end
 end

--- a/spec/sidekiq_unique_jobs/lua/lock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/lock_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "lock.lua" do
   let(:now_f)      { SidekiqUniqueJobs.now_f }
   let(:lock_limit) { 1 }
 
-  shared_context "with a primed key", with_primed_key: true do
+  shared_context "with a primed key", :with_primed_key do
     before do
       call_script(:queue, key.to_a, argv_one)
       rpoplpush(key.queued, key.primed)

--- a/spec/sidekiq_unique_jobs/lua/unlock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/unlock_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "unlock.lua" do
   let(:locked_jid) { job_id_one }
   let(:lock_limit) { 1 }
 
-  shared_context "with a lock", with_a_lock: true do
+  shared_context "with a lock", :with_a_lock do
     before do
       call_script(:queue, key.to_a, argv_one)
       rpoplpush(key.queued, key.primed)
@@ -172,10 +172,10 @@ RSpec.describe "unlock.lua" do
       it "does not unlock" do
         expect { unlock }.to change { changelogs.count }.by(1)
 
-        expect(queued.count).to be == 0
-        expect(primed.count).to be == 0
+        expect(queued.count).to eq 0
+        expect(primed.count).to eq 0
 
-        expect(locked.count).to be == 1
+        expect(locked.count).to eq 1
         expect(locked.entries).to contain_exactly(job_id_two)
         expect(locked[job_id_two].to_f).to be_within(0.5).of(now_f)
       end
@@ -189,9 +189,9 @@ RSpec.describe "unlock.lua" do
         expect(queued.count).to eq(1)
         expect(queued.entries).to contain_exactly("1")
 
-        expect(primed.count).to be == 0
+        expect(primed.count).to eq 0
 
-        expect(locked.count).to be == 0
+        expect(locked.count).to eq 0
         expect(locked.entries).to eq([])
         expect(locked[job_id_one]).to be_nil
       end

--- a/spec/sidekiq_unique_jobs/middleware/server/until_and_while_executing_spec.rb
+++ b/spec/sidekiq_unique_jobs/middleware/server/until_and_while_executing_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/DescribeMethod
+# rubocop:disable RSpec/SpecFilePathFormat, RSpec/FilePath, RSpec/DescribeMethod
 RSpec.describe SidekiqUniqueJobs::Middleware::Server, "lock: :until_and_while_executing" do
   let(:server) { described_class.new }
 
@@ -46,4 +46,4 @@ RSpec.describe SidekiqUniqueJobs::Middleware::Server, "lock: :until_and_while_ex
     end
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/DescribeMethod
+# rubocop:enable RSpec/SpecFilePathFormat, RSpec/FilePath, RSpec/DescribeMethod

--- a/spec/sidekiq_unique_jobs/redis/hash_spec.rb
+++ b/spec/sidekiq_unique_jobs/redis/hash_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe SidekiqUniqueJobs::Redis::Hash do
     subject(:count) { entity.count }
 
     context "without entries" do
-      it { is_expected.to be == 0 }
+      it { is_expected.to eq 0 }
     end
 
     context "with entries" do
       before { hset(digest, job_id, now_f) }
 
-      it { is_expected.to be == 1 }
+      it { is_expected.to eq 1 }
     end
   end
 end

--- a/spec/sidekiq_unique_jobs/redis/set_spec.rb
+++ b/spec/sidekiq_unique_jobs/redis/set_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe SidekiqUniqueJobs::Redis::Set do
     subject(:count) { entity.count }
 
     context "without entries" do
-      it { is_expected.to be == 0 }
+      it { is_expected.to eq 0 }
     end
 
     context "with entries" do
       before { sadd(digest, job_id) }
 
-      it { is_expected.to be == 1 }
+      it { is_expected.to eq 1 }
     end
   end
 end

--- a/spec/sidekiq_unique_jobs/redis/sorted_set_spec.rb
+++ b/spec/sidekiq_unique_jobs/redis/sorted_set_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe SidekiqUniqueJobs::Redis::SortedSet do
     context "when given an array of arrays" do
       let(:values) { [[1.0, "string"], [2.0, "other"]] }
 
-      it { is_expected.to be == 2 }
+      it { is_expected.to eq 2 }
     end
 
     context "when given a string entries" do
       let(:values) { "abcdef" }
 
-      it { is_expected.to be == 1 }
+      it { is_expected.to eq 1 }
     end
   end
 
@@ -50,13 +50,13 @@ RSpec.describe SidekiqUniqueJobs::Redis::SortedSet do
     subject(:count) { entity.count }
 
     context "without entries" do
-      it { is_expected.to be == 0 }
+      it { is_expected.to eq 0 }
     end
 
     context "with entries" do
       before { zadd(digest, now_f, job_id) }
 
-      it { is_expected.to be == 1 }
+      it { is_expected.to eq 1 }
     end
   end
 
@@ -64,7 +64,7 @@ RSpec.describe SidekiqUniqueJobs::Redis::SortedSet do
     subject(:clear) { entity.clear }
 
     context "without entries" do
-      it { is_expected.to be == 0 }
+      it { is_expected.to eq 0 }
     end
 
     context "with entries" do
@@ -77,7 +77,7 @@ RSpec.describe SidekiqUniqueJobs::Redis::SortedSet do
         zcard(digest)
       end
 
-      it { is_expected.to be == 100 }
+      it { is_expected.to eq 100 }
     end
   end
 
@@ -105,7 +105,7 @@ RSpec.describe SidekiqUniqueJobs::Redis::SortedSet do
     context "with entries" do
       before { zadd(digest, now_f, job_id) }
 
-      it { is_expected.to be == 0 }
+      it { is_expected.to eq 0 }
     end
   end
 end

--- a/spec/sidekiq_unique_jobs/redis/string_spec.rb
+++ b/spec/sidekiq_unique_jobs/redis/string_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe SidekiqUniqueJobs::Redis::String do
     subject(:count) { entity.count }
 
     context "without entries" do
-      it { is_expected.to be == 0 }
+      it { is_expected.to eq 0 }
     end
 
     context "with entries" do
       before { set(digest, job_id) }
 
-      it { is_expected.to be == 1 }
+      it { is_expected.to eq 1 }
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe SidekiqUniqueJobs::Redis::String do
     context "with entries" do
       before { set(digest, job_id) }
 
-      it { is_expected.to be == job_id }
+      it { is_expected.to eq job_id }
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe SidekiqUniqueJobs::Redis::String do
     context "with entries" do
       before { set(digest, job_id) }
 
-      it { is_expected.to be == 1 }
+      it { is_expected.to eq 1 }
     end
   end
 end

--- a/spec/support/shared_contexts/with_sidekiq_options.rb
+++ b/spec/support/shared_contexts/with_sidekiq_options.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_context "with global config", with_global_config: true do
+RSpec.shared_context "with global config", :with_global_config do
   let(:global_config) { {} }
 
   around do |example|
@@ -8,7 +8,7 @@ RSpec.shared_context "with global config", with_global_config: true do
   end
 end
 
-RSpec.shared_context "with job options", with_job_options: true do
+RSpec.shared_context "with job options", :with_job_options do
   let(:job_options) { {} }
 
   around do |example|
@@ -16,7 +16,7 @@ RSpec.shared_context "with job options", with_job_options: true do
   end
 end
 
-RSpec.shared_context "with sidekiq options", with_sidekiq_options: true do |**_options|
+RSpec.shared_context "with sidekiq options", :with_sidekiq_options do |**_options|
   let(:sidekiq_options) { {} }
 
   around do |example|


### PR DESCRIPTION
According to [Sidekiq 7.2 changelog](https://github.com/sidekiq/sidekiq/blob/main/Changes.md#720), using `byscore: true` and `nx: true` will now throw, which causes Sidekiq not to start up anymore when using `sidekiq-unique-jobs`