### PR TITLE
Fix Testing Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,6 @@ end
 #spec/workers/bad_worker_spec.rb
 
 require "sidekiq_unique_jobs/testing"
-#OR
-require "sidekiq_unique_jobs/rspec/matchers"
 
 RSpec.describe BadWorker do
   specify { expect(described_class).to have_valid_sidekiq_options }


### PR DESCRIPTION
I ran into a known issue[1] when trying to bring this gem into my project.

It turns out the instructions were just out of date. If you merely include the RSpec file it misses other necessary requires. The noted file does everything you need regardless of testing framework.