### PR TITLE
fix: ensure a new lock isn't conflicting with itself

### DIFF
--- a/lib/sidekiq_unique_jobs/batch_delete.rb
+++ b/lib/sidekiq_unique_jobs/batch_delete.rb
@@ -9,7 +9,7 @@ module SidekiqUniqueJobs
   class BatchDelete
     #
     # @return [Integer] the default batch size
-    BATCH_SIZE = 100
+    BATCH_SIZE = 500
 
     #
     # @return [Array<String>] Supported key suffixes

--- a/lib/sidekiq_unique_jobs/constants.rb
+++ b/lib/sidekiq_unique_jobs/constants.rb
@@ -15,6 +15,7 @@ module SidekiqUniqueJobs
   DEAD_VERSION          = "uniquejobs:dead"
   DIGESTS               = "uniquejobs:digests"
   EXPIRING_DIGESTS      = "uniquejobs:expiring_digests"
+  ORPHANED_DIGESTS      = "uniquejobs:orphaned_digests"
   ERRORS                = "errors"
   JID                   = "jid"
   LIMIT                 = "limit"

--- a/lib/sidekiq_unique_jobs/lock.rb
+++ b/lib/sidekiq_unique_jobs/lock.rb
@@ -33,7 +33,7 @@ module SidekiqUniqueJobs
     #
     # @return [Lock] a newly lock that has been locked
     #
-    def self.create(digest, job_id, lock_info = {}, time: Timing.now_f, score: nil)
+    def self.create(digest, job_id, lock_info: {}, time: Timing.now_f, score: nil)
       lock = new(digest, time: time)
       lock.lock(job_id, lock_info, score)
       lock

--- a/lib/sidekiq_unique_jobs/orphans/reaper.rb
+++ b/lib/sidekiq_unique_jobs/orphans/reaper.rb
@@ -27,6 +27,7 @@ module SidekiqUniqueJobs
         none: SidekiqUniqueJobs::Orphans::NullReaper,
         nil => SidekiqUniqueJobs::Orphans::NullReaper,
         false => SidekiqUniqueJobs::Orphans::NullReaper,
+        true => SidekiqUniqueJobs::Orphans::RubyReaper,
       }.freeze
 
       #

--- a/lib/sidekiq_unique_jobs/orphans/reaper.rb
+++ b/lib/sidekiq_unique_jobs/orphans/reaper.rb
@@ -22,7 +22,7 @@ module SidekiqUniqueJobs
       #
       # @return [Hash<Symbol, SidekiqUniqueJobs::Orphans::Reaper] the current implementation of reapers
       REAPERS = {
-        lua: SidekiqUniqueJobs::Orphans::LuaReaper,
+        lua: SidekiqUniqueJobs::Orphans::RubyReaper,
         ruby: SidekiqUniqueJobs::Orphans::RubyReaper,
         none: SidekiqUniqueJobs::Orphans::NullReaper,
         nil => SidekiqUniqueJobs::Orphans::NullReaper,

--- a/lib/sidekiq_unique_jobs/redis/sorted_set.rb
+++ b/lib/sidekiq_unique_jobs/redis/sorted_set.rb
@@ -48,6 +48,14 @@ module SidekiqUniqueJobs
         end
       end
 
+      def byscore(min, max, offset: nil, count: nil)
+        redis do |conn|
+          return conn.zrange(key, min, max, "byscore") unless offset && count
+
+          conn.zrange(key, min, max, "byscore", "limit", offset, count)
+        end
+      end
+
       #
       # Return the zrak of the member
       #

--- a/spec/sidekiq_unique_jobs/lock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SidekiqUniqueJobs::Lock do
   its(:to_s)    { is_expected.to eq(expected_string) }
 
   describe ".create" do
-    subject(:create) { described_class.create(key, job_id, lock_info) }
+    subject(:create) { described_class.create(key, job_id, lock_info: lock_info) }
 
     it "creates all expected keys in redis" do
       create
@@ -77,7 +77,7 @@ RSpec.describe SidekiqUniqueJobs::Lock do
   describe "#del" do
     subject(:del) { lock.del }
 
-    let(:lock) { described_class.create(key, job_id, info) }
+    let(:lock) { described_class.create(key, job_id, lock_info: info) }
 
     it "creates keys and adds job_id to locked hash" do
       expect { lock }.to change { entity.locked_jids }.to([job_id])

--- a/spec/sidekiq_unique_jobs/lua/reap_orphans_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/reap_orphans_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "reap_orphans.lua" do
   end
   let(:argv)       { [100, threshold] }
   let(:digest)     { "uniquejobs:digest" }
-  let(:lock)       { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info) }
+  let(:lock)       { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info: lock_info) }
   let(:job_id)     { "job_id" }
   let(:item)       { raw_item }
   let(:created_at) { (Time.now - 1000).to_f }

--- a/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
@@ -5,8 +5,17 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
   let(:digest)   { "uniquejobs:digest" }
   let(:job_id)   { "job_id" }
   let(:item)     { raw_item }
-  let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info) }
+  let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info, score: score) }
   let(:raw_item) { { "class" => MyUniqueJob, "args" => [], "jid" => job_id, "lock_digest" => digest } }
+
+  let(:score) do
+    (
+      Time.now -
+        SidekiqUniqueJobs.config.reaper_timeout -
+        SidekiqUniqueJobs::Orphans::RubyReaper::SIDEKIQ_BEAT_PAUSE -
+        100
+    ).to_f
+  end
   let(:lock_info) do
     {
       "job_id" => job_id,

--- a/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/reaper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
   let(:digest)   { "uniquejobs:digest" }
   let(:job_id)   { "job_id" }
   let(:item)     { raw_item }
-  let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info, score: score) }
+  let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info: lock_info, score: score) }
   let(:raw_item) { { "class" => MyUniqueJob, "args" => [], "jid" => job_id, "lock_digest" => digest } }
 
   let(:score) do
@@ -161,7 +161,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::Reaper do
           end
 
           context "when digest has :RUN suffix" do
-            let(:lock) { SidekiqUniqueJobs::Lock.create("#{digest}:RUN", job_id, lock_info) }
+            let(:lock) { SidekiqUniqueJobs::Lock.create("#{digest}:RUN", job_id, lock_info: lock_info) }
 
             context "that matches current digest" do # rubocop:disable RSpec/NestedGroups
               let(:created_at) { (Time.now - (reaper_timeout + 100)).to_f }

--- a/spec/sidekiq_unique_jobs/orphans/ruby_reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/ruby_reaper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::RubyReaper do
   let(:digest)   { "uniquejobs:digest" }
   let(:job_id)   { "job_id" }
   let(:item)     { raw_item }
-  let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info, score: score) }
+  let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info: lock_info, score: score) }
   let(:raw_item) { { "class" => MyUniqueJob, "args" => [], "jid" => job_id, "lock_digest" => digest } }
   let(:lock_info) do
     {

--- a/spec/sidekiq_unique_jobs/orphans/ruby_reaper_spec.rb
+++ b/spec/sidekiq_unique_jobs/orphans/ruby_reaper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SidekiqUniqueJobs::Orphans::RubyReaper do
   let(:digest)   { "uniquejobs:digest" }
   let(:job_id)   { "job_id" }
   let(:item)     { raw_item }
-  let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info) }
+  let(:lock)     { SidekiqUniqueJobs::Lock.create(digest, job_id, lock_info, score: score) }
   let(:raw_item) { { "class" => MyUniqueJob, "args" => [], "jid" => job_id, "lock_digest" => digest } }
   let(:lock_info) do
     {
@@ -18,6 +18,15 @@ RSpec.describe SidekiqUniqueJobs::Orphans::RubyReaper do
       "lock_args" => [],
       "worker" => "MyUniqueJob",
     }
+  end
+
+  let(:score) do
+    (
+      Time.now -
+        SidekiqUniqueJobs.config.reaper_timeout -
+        SidekiqUniqueJobs::Orphans::RubyReaper::SIDEKIQ_BEAT_PAUSE -
+        100
+    ).to_f
   end
 
   before do


### PR DESCRIPTION
This should also improve performance. I still need to create performance tests or benchmarks to tell for sure. 

My test suite time is down to:

![CleanShot 2024-02-07 at 12 29 05@2x](https://github.com/mhenrixon/sidekiq-unique-jobs/assets/106795/721dbd8c-8c2a-48b6-afed-e6201d33d948)

Closes #824