### PR TITLE
Add digest scores for faster deletes in sorted sets

### DIFF
--- a/lib/sidekiq_unique_jobs/locksmith.rb
+++ b/lib/sidekiq_unique_jobs/locksmith.rb
@@ -82,7 +82,7 @@ module SidekiqUniqueJobs
     # Deletes the lock regardless of if it has a pttl set
     #
     def delete!
-      call_script(:delete, key.to_a, [job_id, config.pttl, config.type, config.limit]).to_i.positive?
+      call_script(:delete, key.to_a, argv).to_i.positive?
     end
 
     #
@@ -362,7 +362,11 @@ module SidekiqUniqueJobs
     end
 
     def argv
-      [job_id, config.pttl, config.type, config.limit]
+      [job_id, config.pttl, config.type, config.limit, lock_score]
+    end
+
+    def lock_score
+      item[AT].to_s
     end
 
     def lock_info
@@ -375,6 +379,7 @@ module SidekiqUniqueJobs
         TYPE => config.type,
         LOCK_ARGS => item[LOCK_ARGS],
         TIME => now_f,
+        AT => item[AT],
       )
     end
 

--- a/lib/sidekiq_unique_jobs/lua/delete.lua
+++ b/lib/sidekiq_unique_jobs/lua/delete.lua
@@ -13,14 +13,15 @@ local job_id       = ARGV[1]
 local pttl         = tonumber(ARGV[2])
 local lock_type    = ARGV[3]
 local limit        = tonumber(ARGV[4])
+local lock_score   = ARGV[5]
 -------- END lock arguments -----------
 
 --------  BEGIN injected arguments --------
-local current_time = tonumber(ARGV[5])
-local debug_lua    = tostring(ARGV[6]) == "1"
-local max_history  = tonumber(ARGV[7])
-local script_name  = tostring(ARGV[8]) .. ".lua"
-local redisversion = tostring(ARGV[9])
+local current_time = tonumber(ARGV[6])
+local debug_lua    = tostring(ARGV[7]) == "1"
+local max_history  = tonumber(ARGV[8])
+local script_name  = tostring(ARGV[9]) .. ".lua"
+local redisversion = tostring(ARGV[10])
 ---------  END injected arguments ---------
 
 --------  BEGIN local functions --------

--- a/lib/sidekiq_unique_jobs/lua/queue.lua
+++ b/lib/sidekiq_unique_jobs/lua/queue.lua
@@ -10,18 +10,19 @@ local digests   = KEYS[7]
 
 
 -------- BEGIN lock arguments ---------
-local job_id    = ARGV[1]      -- The job_id that was previously primed
-local pttl      = tonumber(ARGV[2])
-local lock_type = ARGV[3]
-local limit     = tonumber(ARGV[4])
+local job_id     = ARGV[1]      -- The job_id that was previously primed
+local pttl       = tonumber(ARGV[2])
+local lock_type  = ARGV[3]
+local limit      = tonumber(ARGV[4])
+local lock_score = ARGV[5]
 -------- END lock arguments -----------
 
 
 --------  BEGIN injected arguments --------
-local current_time = tonumber(ARGV[5])
-local debug_lua    = tostring(ARGV[6]) == "1"
-local max_history  = tonumber(ARGV[7])
-local script_name  = tostring(ARGV[8]) .. ".lua"
+local current_time = tonumber(ARGV[6])
+local debug_lua    = tostring(ARGV[7]) == "1"
+local max_history  = tonumber(ARGV[8])
+local script_name  = tostring(ARGV[9]) .. ".lua"
 ---------  END injected arguments ---------
 
 

--- a/lib/sidekiq_unique_jobs/lua/shared/_delete_from_queue.lua
+++ b/lib/sidekiq_unique_jobs/lua/shared/_delete_from_queue.lua
@@ -1,22 +1,22 @@
 local function delete_from_queue(queue, digest)
-  local per    = 50
-  local total  = redis.call("LLEN", queue)
-  local index  = 0
-  local result = nil
+  local total = redis.call("LLEN", queue)
+  local per   = 50
 
-  while (index < total) do
-    local items = redis.call("LRANGE", queue, index, index + per -1)
+  for index = 0, total, per do
+    local items = redis.call("LRANGE", queue, index, index + per - 1)
+
     if #items == 0 then
       break
     end
+
     for _, item in pairs(items) do
       if string.find(item, digest) then
         redis.call("LREM", queue, 1, item)
-        result = item
-        break
+
+        return item
       end
     end
-    index = index + per
   end
-  return result
+
+  return nil
 end

--- a/lib/sidekiq_unique_jobs/lua/unlock.lua
+++ b/lib/sidekiq_unique_jobs/lua/unlock.lua
@@ -10,19 +10,20 @@ local digests   = KEYS[7]
 
 
 -------- BEGIN lock arguments ---------
-local job_id    = ARGV[1]
-local pttl      = tonumber(ARGV[2])
-local lock_type = ARGV[3]
-local limit     = tonumber(ARGV[4])
+local job_id     = ARGV[1]
+local pttl       = tonumber(ARGV[2])
+local lock_type  = ARGV[3]
+local limit      = tonumber(ARGV[4])
+local lock_score = ARGV[5]
 -------- END lock arguments -----------
 
 
 --------  BEGIN injected arguments --------
-local current_time = tonumber(ARGV[5])
-local debug_lua    = tostring(ARGV[6]) == "1"
-local max_history  = tonumber(ARGV[7])
-local script_name  = tostring(ARGV[8]) .. ".lua"
-local redisversion = ARGV[9]
+local current_time = tonumber(ARGV[6])
+local debug_lua    = tostring(ARGV[7]) == "1"
+local max_history  = tonumber(ARGV[8])
+local script_name  = tostring(ARGV[9]) .. ".lua"
+local redisversion = ARGV[10]
 ---------  END injected arguments ---------
 
 

--- a/spec/performance/unique_job_on_conflict_replace_spec.rb
+++ b/spec/performance/unique_job_on_conflict_replace_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe UniqueJobOnConflictReplace, :perf do
+  let(:lock_prefix)  { described_class.sidekiq_options.fetch("lock_prefix")  { SidekiqUniqueJobs.config.lock_prefix } }
+  let(:lock_timeout) { described_class.sidekiq_options.fetch("lock_timeout") { SidekiqUniqueJobs.config.lock_timeout } }
+  let(:lock_ttl)     { described_class.sidekiq_options.fetch("lock_ttl")     { SidekiqUniqueJobs.config.lock_ttl } }
+  let(:queue)        { described_class.sidekiq_options["queue"] }
+  let(:on_conflict)  { described_class.sidekiq_options["on_conflict"] }
+  let(:lock)         { described_class.sidekiq_options["lock"] }
+
+  before do
+    flushdb
+  end
+
+  context "when schedule queue is large" do
+    it "locks and replaces quickly" do
+      (0..100_000).each_slice(1_000) do |nums|
+        redis do |conn|
+          conn.pipelined do |pipeline|
+            nums.each do |num|
+              created_at   = Time.now.to_f
+              scheduled_at = created_at + rand(3_600..2_592_000)
+
+              payload = {
+                "retry" => true,
+                "queue" => queue,
+                "lock" => lock,
+                "on_conflict" => on_conflict,
+                "class" => described_class.name,
+                "args" => [num, { "type" => "extremely unique" }],
+                "jid" => SecureRandom.hex(12),
+                "created_at" => created_at,
+                "lock_timeout" => lock_timeout,
+                "lock_ttl" => lock_ttl,
+                "lock_prefix" => lock_prefix,
+                "lock_args" => [num, { "type" => "extremely unique" }],
+                "lock_digest" => "#{lock_prefix}:#{SecureRandom.hex}",
+              }
+
+              pipeline.zadd("schedule", scheduled_at, payload.to_json)
+            end
+          end
+        end
+      end
+
+      # queueing it once at the end of the queue should succeed
+      expect(described_class.perform_in(2_592_000, 100_000, { "type" => "extremely unique" })).not_to be_nil
+
+      # queueing it again should be performant
+      expect do
+        described_class.perform_in(2_592_000, 100_000, { "type" => "extremely unique" })
+      end.to perform_under(10).ms
+    end
+  end
+end

--- a/spec/sidekiq_unique_jobs/lua/delete_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/delete_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "delete.lua" do
       lock_ttl,
       lock_type,
       lock_limit,
+      lock_score,
     ]
   end
   let(:job_id)     { "jobid" }
@@ -22,6 +23,8 @@ RSpec.describe "delete.lua" do
   let(:lock_ttl)   { nil }
   let(:locked_jid) { job_id }
   let(:lock_limit) { 1 }
+  let(:now_f)      { SidekiqUniqueJobs.now_f }
+  let(:lock_score) { now_f.to_s }
 
   context "when queued" do
     before do

--- a/spec/sidekiq_unique_jobs/lua/lock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/lock_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe "lock.lua" do
   subject(:lock) { call_script(:lock, key.to_a, argv_one) }
 
-  let(:argv_one)   { [job_id_one, lock_ttl, lock_type, lock_limit] }
-  let(:argv_two)   { [job_id_two, lock_ttl, lock_type, lock_limit] }
+  let(:argv_one)   { [job_id_one, lock_ttl, lock_type, lock_limit, lock_score] }
+  let(:argv_two)   { [job_id_two, lock_ttl, lock_type, lock_limit, lock_score] }
   let(:job_id_one) { "job_id_one" }
   let(:job_id_two) { "job_id_two" }
   let(:lock_type)  { :until_executed }
@@ -19,6 +19,7 @@ RSpec.describe "lock.lua" do
   let(:locked_jid) { job_id_one }
   let(:now_f)      { SidekiqUniqueJobs.now_f }
   let(:lock_limit) { 1 }
+  let(:lock_score) { now_f.to_s }
 
   shared_context "with a primed key", :with_primed_key do
     before do

--- a/spec/sidekiq_unique_jobs/lua/queue_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/queue_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "queue.lua" do
       lock_pttl,
       lock_type,
       lock_limit,
+      lock_score,
     ]
   end
   let(:digest)     { "uniquejobs:digest" }
@@ -21,6 +22,7 @@ RSpec.describe "queue.lua" do
   let(:locked_jid) { job_id }
   let(:lock_limit) { 1 }
   let(:now_f)      { SidekiqUniqueJobs.now_f }
+  let(:lock_score) { now_f.to_s }
 
   before do
     flush_redis
@@ -54,7 +56,7 @@ RSpec.describe "queue.lua" do
 
   context "when queued by another job_id" do
     before do
-      call_script(:queue, key.to_a, [job_id_two, lock_pttl, lock_type, lock_limit])
+      call_script(:queue, key.to_a, [job_id_two, lock_pttl, lock_type, lock_limit, lock_score])
     end
 
     context "with lock_limit 1" do
@@ -94,7 +96,7 @@ RSpec.describe "queue.lua" do
 
   context "when queued by same job_id" do
     before do
-      call_script(:queue, key.to_a, [job_id_one, lock_pttl, lock_type, lock_limit])
+      call_script(:queue, key.to_a, [job_id_one, lock_pttl, lock_type, lock_limit, lock_score])
     end
 
     it "stores the right keys in redis" do
@@ -113,9 +115,9 @@ RSpec.describe "queue.lua" do
 
   context "when primed by another job_id" do
     before do
-      call_script(:queue, key.to_a, [job_id_two, lock_pttl, lock_type, lock_limit])
+      call_script(:queue, key.to_a, [job_id_two, lock_pttl, lock_type, lock_limit, lock_score])
       rpoplpush(key.queued, key.primed)
-      call_script(:lock, key.to_a, [job_id_two, lock_pttl, lock_type, lock_limit])
+      call_script(:lock, key.to_a, [job_id_two, lock_pttl, lock_type, lock_limit, lock_score])
     end
 
     context "with lock_limit 1" do

--- a/spec/sidekiq_unique_jobs/lua/unlock_spec.rb
+++ b/spec/sidekiq_unique_jobs/lua/unlock_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe "unlock.lua" do
   subject(:unlock) { call_script(:unlock, key.to_a, argv_one) }
 
-  let(:argv_one)   { [job_id_one, lock_ttl, lock_type, lock_limit] }
-  let(:argv_two)   { [job_id_two, lock_ttl, lock_type, lock_limit] }
+  let(:argv_one)   { [job_id_one, lock_ttl, lock_type, lock_limit, lock_score] }
+  let(:argv_two)   { [job_id_two, lock_ttl, lock_type, lock_limit, lock_score] }
   let(:job_id_one) { "job_id_one" }
   let(:job_id_two) { "job_id_two" }
   let(:lock_type)  { :until_executed }
@@ -17,6 +17,7 @@ RSpec.describe "unlock.lua" do
   let(:lock_ttl)   { nil }
   let(:locked_jid) { job_id_one }
   let(:lock_limit) { 1 }
+  let(:lock_score) { now_f.to_s }
 
   shared_context "with a lock", :with_a_lock do
     before do

--- a/spec/support/sidekiq_unique_jobs/testing.rb
+++ b/spec/support/sidekiq_unique_jobs/testing.rb
@@ -59,12 +59,12 @@ module SidekiqUniqueJobs
         redis { |conn| conn.debug(*args) }
       end
 
-      def flushall(options = nil)
-        redis { |conn| conn.flushall(options) }
+      def flushall(...)
+        redis { |conn| conn.flushall(...) }
       end
 
-      def flushdb(options = nil)
-        redis { |conn| conn.flushdb(options) }
+      def flushdb(...)
+        redis { |conn| conn.flushdb(...) }
       end
 
       def info(_cmd = nil)

--- a/spec/support/workers/unique_job_on_conflict_replace.rb
+++ b/spec/support/workers/unique_job_on_conflict_replace.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# :nocov:
+
+class UniqueJobOnConflictReplace
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_executing,
+                  queue: :customqueue,
+                  on_conflict: :replace
+
+  def perform(one, two)
+    [one, two]
+  end
+end

--- a/spec/workers/unique_job_on_conflict_replace_spec.rb
+++ b/spec/workers/unique_job_on_conflict_replace_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe UniqueJobOnConflictReplace do
+  it_behaves_like "sidekiq with options" do
+    let(:options) do
+      {
+        "lock" => :until_executing,
+        "on_conflict" => :replace,
+        "queue" => :customqueue,
+        "retry" => true,
+      }
+    end
+  end
+
+  it_behaves_like "a performing worker" do
+    let(:args) { ["hundred", { "type" => "extremely unique", "id" => 44 }] }
+  end
+end


### PR DESCRIPTION
Closes #668. First pass on [my idea](https://github.com/mhenrixon/sidekiq-unique-jobs/issues/668#issuecomment-1934461714) of using scores to "skip ahead" so that we don't have to iterate the entire sorted set when a unique job is deleted. Let me know what you think. I'm sure I'm missing some edge cases, since I don't have the domain knowledge you do here. This _should_ be backwards compatible, reverting back to previous behavior if a score doesn't exist.

I still want to add a performance test with a large schedule queue to make sure this actually works.