### PR TITLE
tweak changelog for 8.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Fixed bugs:**
 
+- note: The RCE vulnerability was a false alarm, `sidekiq-unique-jobs` was not vulnerable to RCE. You can find additional information in the PR linked below.
 - fix\(rce\): prevent remot code execution [\#833](https://github.com/mhenrixon/sidekiq-unique-jobs/pull/833) ([mhenrixon](https://github.com/mhenrixon))
 
 ## [v8.0.8](https://github.com/mhenrixon/sidekiq-unique-jobs/tree/v8.0.8) (2024-02-12)


### PR DESCRIPTION
Makes an explicit note that this was a non-issue. Dependabot uses this changelog file to provide context snippets in PR descriptions. My hope is that even though there has been no new release this will be picked up anyways.

Alternativly, the changelog entry could be removed entirely.

Would need backporting to 7.1 I think