### PR TITLE
Improve expiring locks display with filtering and pagination

### DIFF
--- a/lib/sidekiq_unique_jobs/web.rb
+++ b/lib/sidekiq_unique_jobs/web.rb
@@ -61,12 +61,12 @@ module SidekiqUniqueJobs
           page_size: @count,
         )
 
-        erb(unique_template(:locks))
+        erb(unique_template(:expiring_locks))
       end
 
       app.get "/locks/delete_all" do
         digests.delete_by_pattern("*", count: digests.count)
-        expiring_digests.delete_by_pattern("*", count: digests.count)
+        expiring_digests.delete_by_pattern("*", count: expiring_digests.count)
         redirect_to :locks
       end
 

--- a/lib/sidekiq_unique_jobs/web/views/expiring_locks.erb
+++ b/lib/sidekiq_unique_jobs/web/views/expiring_locks.erb
@@ -1,0 +1,59 @@
+<header class="row">
+  <div class="col-sm-5">
+    <h3>
+    <%= t('Locks') %>
+    </h3>
+  </div>
+  <form action="<%= root_path %>expiring_locks" class="form form-inline" method="get">
+    <%= csrf_tag %>
+    <input name="filter" class="form-control" type="text" value="<%= @filter %>" />
+
+    <button class="btn btn-default" type="submit">
+      <%= t('Filter') %>
+    </button>
+
+  </form>
+
+  <% if @locks.any? && @total_size > @count %>
+    <div class="col-sm-4">
+      <%= erb unique_template(:_paging), locals: { url: "#{root_path}expiring_locks" } %>
+    </div>
+  <% end %>
+</header>
+
+<% if @locks.any? %>
+  <div class="table_container">
+    <table class="table table-striped table-bordered table-hover">
+      <thead>
+        <tr>
+          <th><%= t('Delete') %></th>
+          <th><%= t('Digest') %></th>
+          <th><%= t('Lock') %></th>
+          <th><%= t('Locks') %></th>
+          <th><%= t('Since') %></th>
+        </tr>
+      </thead>
+      <% @locks.each do |lock| %>
+        <tbody>
+          <tr class="lock-row">
+            <td>
+              <form action="<%= root_path %>locks/<%= lock.key %>/delete" method="get">
+                <%= csrf_tag %>
+                <input name="lock" value="<%= h lock.key %>" type="hidden" />
+                <input class="btn btn-danger btn-xs" type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSure') %>" />
+              </form>
+            </td>
+            <td><a href="<%= root_path %>locks/<%= lock.key %>"><%= lock.key %></a></td>
+            <td><%= lock.info["lock"] %></td>
+            <td><%= lock.locked.count %></td>
+            <td><%= _safe_relative_time(lock.created_at) %></td>
+          </tr>
+        </tbody>
+      <% end %>
+    </table>
+
+    <form action="<%= root_path %>locks/delete_all" method="get">
+      <input class="btn btn-danger btn-xs" type="submit" name="delete_all" value="<%= t('DeleteAll') %>" data-confirm="<%= t('AreYouSure') %>" />
+    </form>
+  </div>
+<% end %>


### PR DESCRIPTION
I found some issues with  the expiring locks tab when trying to  troubleshoot another problem. This is a fairly naive improvement  with a lot of repetition, I just wasn't sure what level of path/context was available from the `lock.erb` template so I just made a separate one. Without these changes, it's not possible to filter  or paginate on the Expiring Locks page.

Also included here -  deleting all locks was failing  due to a typo in that method, deleting expiring digests based on the regular digests.count.