### PR TITLE
Remove redundant include to locales (for Sidekiq 8)

### DIFF
--- a/lib/sidekiq_unique_jobs/web.rb
+++ b/lib/sidekiq_unique_jobs/web.rb
@@ -108,8 +108,6 @@ begin
     Sidekiq::Web.tabs["Expiring Locks"] = "expiring_locks"
     Sidekiq::Web.tabs["Changelogs"]     = "changelogs"
   end
-
-  Sidekiq::Web.settings.locales << File.join(File.dirname(__FILE__), "locales")
 rescue NameError, LoadError => e
   SidekiqUniqueJobs.logger.error(e)
 end


### PR DESCRIPTION
This generates errors for Sidekiq 8, and looks like this gem does not have any translation files, so it can be just removed?
```
ERROR: undefined method 'settings' for class Sidekiq::Web
```
