### PR TITLE
update Reject#kill_with_options? for Ruby 3 kwargs

### DIFF
--- a/lib/sidekiq_unique_jobs/on_conflict/reject.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/reject.rb
@@ -28,7 +28,8 @@ module SidekiqUniqueJobs
       # @return [false] when Sidekiq::Deadset#kill does not take multiple arguments
       #
       def kill_with_options?
-        Sidekiq::DeadSet.instance_method(:kill).arity > 1
+        kill_arity = Sidekiq::DeadSet.instance_method(:kill).arity
+        kill_arity > 1 || kill_arity < -1
       end
 
       #

--- a/lib/sidekiq_unique_jobs/on_conflict/reject.rb
+++ b/lib/sidekiq_unique_jobs/on_conflict/reject.rb
@@ -29,6 +29,14 @@ module SidekiqUniqueJobs
       #
       def kill_with_options?
         kill_arity = Sidekiq::DeadSet.instance_method(:kill).arity
+        # Method#arity returns:
+        #   1. a nonnegative number for methods that take a fixed number of arguments.
+        #   2. A negative number if it takes a variable number of arguments.
+        # Keyword arguments are considered a single argument, and are considered optional unless one of the kwargs is
+        # required.
+        # Therefore, to determine if `Sidekiq::DeadSet#kill` accepts options beyond the single positional payload
+        # argument, we need to check whether the absolute value of the arity is greater than 1.
+        # See: https://apidock.com/ruby/Method/arity
         kill_arity > 1 || kill_arity < -1
       end
 

--- a/spec/sidekiq_unique_jobs/on_conflict/reject_spec.rb
+++ b/spec/sidekiq_unique_jobs/on_conflict/reject_spec.rb
@@ -62,4 +62,12 @@ RSpec.describe SidekiqUniqueJobs::OnConflict::Reject do
       expect(deadset).to have_received(:kill).with(payload, notify_failure: false)
     end
   end
+
+  describe "#kill_with_options?" do
+    it 'works when Sidekiq::DeadSet#kill takes an optional kwarg hash' do
+      kill_method = ->(payload, opts = {}) { false }
+      allow(Sidekiq::DeadSet).to receive(:instance_method).with(:kill).and_return(kill_method)
+      expect(strategy.kill_with_options?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
Sometime in the past either the definition of `arity` or `Sidekiq::Deadset#kill` was changed. Currently https://apidock.com/ruby/Method/arity returns negative numbers when there are optional arguments, which this method does not consider. The current (and what's been the state for many years now) version of this method takes an optional hash / `opts` argument": https://github.com/sidekiq/sidekiq/blob/main/lib/sidekiq/api.rb#L900, so the current method is just always returning `false`. 

My suspicion is that this changed around Ruby3 with the kwarg changes, but I'm not sure. 

This updates the method to return `true` if it takes more than one required argument, whether there are optional args or not. 