### PR TITLE
(v7.1) Add support for lock_ttl to be a Proc/class method

### DIFF
--- a/lib/sidekiq_unique_jobs/lock_ttl.rb
+++ b/lib/sidekiq_unique_jobs/lock_ttl.rb
@@ -74,18 +74,23 @@ module SidekiqUniqueJobs
 
       return unless ttl
 
-      timing = case ttl
-           when String, Numeric
-             ttl.to_i
-           when Proc
-             ttl.call(item[ARGS])
-           when Symbol
-             job_class.send(ttl, item[ARGS])
-           else
-             return nil
-           end
+      timing = timing(ttl)
+      return unless timing
 
       timing.to_i + time_until_scheduled
+    end
+
+    private
+
+    def timing(ttl)
+      case ttl
+      when String, Numeric
+        ttl
+      when Proc
+        ttl.call(item[ARGS])
+      when Symbol
+        job_class.send(ttl, item[ARGS])
+      end
     end
   end
 end

--- a/spec/sidekiq_unique_jobs/lock_ttl_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_ttl_spec.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe SidekiqUniqueJobs::LockTTL do
-  let(:calculator)      { described_class.new("class" => job_class_name, "at" => schedule_time) }
+  let(:item)            { { "class" => job_class_name, "at" => schedule_time } }
+  let(:calculator)      { described_class.new(item) }
   let(:job_class_name)  { "MyUniqueJob" }
   let(:schedule_time)   { nil }
+  let(:job_options) do
+    { "lock": :until_executed, "lock_ttl": 7_200, "queue": :customqueue, "retry": 10 }
+  end
+
+  before do
+    allow(MyUniqueJob).to receive(:get_sidekiq_options).and_return(job_options)
+  end
 
   describe "public api" do
     subject { calculator }
@@ -30,6 +38,66 @@ RSpec.describe SidekiqUniqueJobs::LockTTL do
         Timecop.travel(Time.at(now_in_utc)) do
           expect(time_until_scheduled).to be_within(10).of(schedule_time - now_in_utc)
         end
+      end
+    end
+  end
+
+  describe "#calculate" do
+    subject(:calculate) { calculator.calculate }
+
+    context 'when no lock_ttl is set' do
+      let(:item) { { "class" => job_class_name, "lock_ttl" => nil } }
+      let(:job_options) { { "lock": 'until_expired', "lock_ttl" => nil } }
+      
+      it 'returns the default lock_ttl' do
+        expect(calculate).to eq(SidekiqUniqueJobs.config.lock_ttl)
+      end
+
+      it 'returns nil' do
+        SidekiqUniqueJobs.config.lock_ttl = nil
+        expect(calculate).to be_nil
+      end
+    end
+
+    context 'when item lock_ttl is numeric' do
+      let(:item) { { "class" => job_class_name, "lock_ttl" => 10 } }
+
+      it do
+        expect(calculate).to eq(10)
+      end
+    end
+
+    context 'when item lock_ttl is a string' do
+      let(:item) { { "class" => job_class_name, "lock_ttl" => "10" } }
+
+      it do
+        expect(calculate).to eq(10)
+      end
+    end
+
+    context 'when item lock_ttl is a proc' do
+      let(:item) { { "class" => job_class_name, "lock_ttl" => ->(_args) { 20 } } }
+
+      it do
+        expect(calculate).to eq(20)
+      end
+    end
+
+    context 'when item lock_ttl is a function symbol' do
+      let(:job_class_name) { "MyOtherUniqueJob" }
+      let(:item) { { "class" => job_class_name, "lock_ttl" => :ttl_fn } }
+
+      it do
+        stub_const(
+          job_class_name,
+          Class.new do
+            def self.ttl_fn(_args)
+              99
+            end
+          end
+        )
+        
+        expect(calculate).to eq(99)
       end
     end
   end

--- a/spec/sidekiq_unique_jobs/lock_ttl_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_ttl_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SidekiqUniqueJobs::LockTTL do
   let(:job_class_name)  { "MyUniqueJob" }
   let(:schedule_time)   { nil }
   let(:job_options) do
-    { "lock": :until_executed, "lock_ttl": 7_200, "queue": :customqueue, "retry": 10 }
+    { lock: :until_executed, lock_ttl: 7_200, queue: :customqueue, retry: 10 }
   end
 
   before do
@@ -45,21 +45,21 @@ RSpec.describe SidekiqUniqueJobs::LockTTL do
   describe "#calculate" do
     subject(:calculate) { calculator.calculate }
 
-    context 'when no lock_ttl is set' do
+    context "when no lock_ttl is set" do
       let(:item) { { "class" => job_class_name, "lock_ttl" => nil } }
-      let(:job_options) { { "lock": 'until_expired', "lock_ttl" => nil } }
-      
-      it 'returns the default lock_ttl' do
+      let(:job_options) { { lock: "until_expired", "lock_ttl" => nil } }
+
+      it "returns the default lock_ttl" do
         expect(calculate).to eq(SidekiqUniqueJobs.config.lock_ttl)
       end
 
-      it 'returns nil' do
+      it "returns nil" do
         SidekiqUniqueJobs.config.lock_ttl = nil
         expect(calculate).to be_nil
       end
     end
 
-    context 'when item lock_ttl is numeric' do
+    context "when item lock_ttl is numeric" do
       let(:item) { { "class" => job_class_name, "lock_ttl" => 10 } }
 
       it do
@@ -67,7 +67,7 @@ RSpec.describe SidekiqUniqueJobs::LockTTL do
       end
     end
 
-    context 'when item lock_ttl is a string' do
+    context "when item lock_ttl is a string" do
       let(:item) { { "class" => job_class_name, "lock_ttl" => "10" } }
 
       it do
@@ -75,7 +75,7 @@ RSpec.describe SidekiqUniqueJobs::LockTTL do
       end
     end
 
-    context 'when item lock_ttl is a proc' do
+    context "when item lock_ttl is a proc" do
       let(:item) { { "class" => job_class_name, "lock_ttl" => ->(_args) { 20 } } }
 
       it do
@@ -83,9 +83,9 @@ RSpec.describe SidekiqUniqueJobs::LockTTL do
       end
     end
 
-    context 'when item lock_ttl is a function symbol' do
+    context "when item lock_ttl is a function symbol" do
       let(:job_class_name) { "MyOtherUniqueJob" }
-      let(:item) { { "class" => job_class_name, "lock_ttl" => :ttl_fn } }
+      let(:item)           { { "class" => job_class_name, "lock_ttl" => :ttl_fn } }
 
       it do
         stub_const(
@@ -94,9 +94,9 @@ RSpec.describe SidekiqUniqueJobs::LockTTL do
             def self.ttl_fn(_args)
               99
             end
-          end
+          end,
         )
-        
+
         expect(calculate).to eq(99)
       end
     end


### PR DESCRIPTION
Adds the ability to set the `lock_ttl` to a Proc or class method, allowing callers to set the TTL based on job arguments or other runtime information.

For my case, I need to set the `lock_ttl` dynamically based on one of the arguments supplied. I can accomplish this with a Sidekiq Middleware that runs before SidekiqUniqueJobs, but I'd prefer to provide a proc to calculate.

Sample Job

```ruby
class DoSomethingCoolWorker
  # ...
  sidekiq_options lock: :until_expired, lock_ttl: :until_end_of_trial

  def self.until_end_of_trial(args)
    user = User.find(args.first)
    user.trial_ends_at - Time.zone.now
  end
  
  def perform(user_id)
    # ...
  end
end
```