### PR TITLE
Raise unexpected type error for lock ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This lock behaves identically to the [Until Executed](#until-executed) except fo
 class UntilExpired
   include Sidekiq::Workers
 
-  sidekiq_options lock: :until_expired, lock_ttl: 1.day
+  sidekiq_options lock: :until_expired, lock_ttl: 1.day.to_i
 
   def perform
     # Do work

--- a/lib/sidekiq_unique_jobs/lock_ttl.rb
+++ b/lib/sidekiq_unique_jobs/lock_ttl.rb
@@ -93,6 +93,8 @@ module SidekiqUniqueJobs
         ttl.call(item[ARGS])
       when Symbol
         job_class.send(ttl, item[ARGS])
+      else
+        raise ArgumentError, "#{ttl.class} is not supported for lock_ttl"
       end
     end
   end

--- a/spec/sidekiq_unique_jobs/lock_ttl_spec.rb
+++ b/spec/sidekiq_unique_jobs/lock_ttl_spec.rb
@@ -99,6 +99,14 @@ RSpec.describe SidekiqUniqueJobs::LockTTL do
 
         expect(calculate).to eq(99)
       end
+
+      context "when item lock_ttl is a another one" do
+        let(:item) { { "class" => job_class_name, "lock_ttl" => (0..1) } }
+
+        it "raise ArgumentError" do
+          expect { calculate }.to raise_error(ArgumentError, "Range is not supported for lock_ttl")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
fix for https://github.com/mhenrixon/sidekiq-unique-jobs/issues/882

ArgumentError is now raised if lock_ttl is an unexpected type.
Also, the README has been modified accordingly.

This change is to prevent returning nil with an unexpected type and tying up the lock.