### PR TITLE
chore(claude): tier model pins across commands

### DIFF
--- a/.claude/commands/github-ci-failures.md
+++ b/.claude/commands/github-ci-failures.md
@@ -1,0 +1,179 @@
+---
+description: "Use when CI checks are failing on a PR — fetches failure logs, diagnoses root causes, implements fixes, and pushes until CI is green."
+model: sonnet
+argument-hint: "PR number (e.g., 123 or #123)"
+allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(gh run view:*), Bash(git log:*), Bash(git diff:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent
+---
+
+# Fix GitHub CI Failures: $ARGUMENTS
+
+You are diagnosing and fixing CI failures on a GitHub pull request. Work systematically: identify failures, read logs, diagnose root causes, fix locally, verify, push.
+
+## Phase 0: Determine the PR Number
+
+The user may provide a PR number as `$ARGUMENTS`. Parse it flexibly:
+
+- `PR123`, `PR 123`, `pr123` → PR 123
+- `123` → PR 123
+- `#123` → PR 123
+- Empty/blank → auto-detect from current branch
+
+**If no PR number is provided**, detect it automatically:
+
+```bash
+gh pr list --author=@me --head="$(git branch --show-current)" --state=open --json number,title
+```
+
+If exactly one open PR exists for the current branch, use it. If none or multiple, ask the user.
+
+Once you have the PR number, confirm it:
+
+```bash
+gh pr view <PR_NUMBER> --json title,state,url
+```
+
+---
+
+## Phase 1: Identify Failing Checks
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+Categorise each failing check:
+
+| Check Type | Examples | How to Get Logs |
+|------------|----------|----------------|
+| Lint (rubocop) | `rubocop`, `style` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
+| Specs (RSpec) | `rspec`, `test` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
+| Code smell (reek) | `reek` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
+
+Extract the run ID and job IDs from the check URLs. The URL format is:
+`https://github.com/mhenrixon/sidekiq-unique-jobs/actions/runs/<RUN_ID>/job/<JOB_ID>`
+
+If all checks pass or are pending, report that and stop.
+
+---
+
+## Phase 2: Fetch Failure Logs
+
+For each failing check, get the logs:
+
+```bash
+# Get the failed job logs (condensed output)
+gh run view <RUN_ID> --job=<JOB_ID> --log-failed
+```
+
+If `--log-failed` output is too large or unclear, try:
+
+```bash
+# Full log for a specific job
+gh run view <RUN_ID> --job=<JOB_ID> --log 2>&1 | tail -100
+```
+
+---
+
+## Phase 3: Diagnose Each Failure
+
+For each failure, determine the root cause:
+
+### Lint Failures (RuboCop)
+
+Look for:
+- RuboCop offenses: file path, line number, cop name, message
+- Can often be auto-fixed with `bundle exec rubocop -A <file>`
+
+### Code Smell Failures (Reek)
+
+Look for:
+- Reek warnings: smell type, file, line
+- Common smells: TooManyStatements, FeatureEnvy, DuplicateMethodCall
+
+### Spec Failures (RSpec)
+
+Look for:
+- Test name and file path
+- Error class and message
+- Relevant backtrace lines (ignore framework noise)
+- Whether it's a test environment issue vs actual code bug
+
+**Key patterns**:
+- `NameError: uninitialized constant` → missing require or renamed class
+- `NoMethodError: undefined method` → API change, missing method
+- `Redis::CommandError` → Lua script error, Redis version issue
+- `expected: X, got: Y` → logic bug or test needs updating
+- `SidekiqUniqueJobs::` errors → lock/middleware issue
+
+### Appraisal Failures
+
+This project tests against multiple Sidekiq versions via Appraisals. A failure in one appraisal but not others likely indicates a Sidekiq API compatibility issue.
+
+---
+
+## Phase 4: Fix Locally
+
+For each diagnosed failure:
+
+1. **Read the relevant file** to understand context before fixing
+2. **Make the fix** — edit the file
+3. **Verify locally** before committing:
+
+```bash
+# For rubocop failures
+bundle exec rubocop <changed_files>
+
+# For spec failures
+bundle exec rspec <failing_spec_files>
+
+# For reek failures
+bundle exec reek <changed_files>
+```
+
+### Fix Priority Order
+
+1. **Lint/style fixes** first (fast, deterministic)
+2. **Spec failures** second (may require understanding the code change)
+3. **Code smell fixes** third (may need refactoring)
+
+---
+
+## Phase 5: Commit and Push
+
+```bash
+git add <specific_files>
+git commit -m "$(cat <<'EOF'
+fix(ci): <brief description of what was fixed>
+
+- Fix 1 description
+- Fix 2 description
+EOF
+)"
+git push
+```
+
+---
+
+## Phase 6: Verify
+
+After pushing, check if CI has been re-triggered:
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+If there are still pending checks, report which checks are running and what was fixed. Do NOT poll in a loop — report the status and let the user know.
+
+---
+
+## Important Notes
+
+- **Read before fixing** — always read the actual failing code before attempting a fix
+- **Fix the root cause** — don't add `# rubocop:disable` to bypass lint; fix the actual issue
+- **Don't fix unrelated failures** — if a spec was already failing on main, note it but don't fix it in this PR
+- **Lua scripts** — if Lua script changes caused failures, check both the `.lua` file and the shared functions in `lib/sidekiq_unique_jobs/lua/shared/`
+- **Redis operations** — all Redis operations must be atomic via Lua scripts. Don't introduce non-atomic Redis calls.
+- **Appraisal compatibility** — fixes must work across all supported Sidekiq versions
+- **Flaky tests** — if a test passes locally but fails in CI, note it as potentially flaky rather than adding workarounds
+- **Don't retry CI blindly** — diagnose first, fix, then push. Each push triggers a full CI run.
+
+Now begin by determining the PR number and fetching the failing checks.

--- a/.claude/commands/github-review-comments.md
+++ b/.claude/commands/github-review-comments.md
@@ -1,6 +1,6 @@
 ---
 description: "Use when a PR has unresolved review comments that need responses -- evaluates each comment, implements valid fixes, pushes back on incorrect suggestions, and resolves all threads."
-model: claude-opus-4-6
+model: sonnet
 argument-hint: "PR number (e.g., 123 or #123)"
 allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(git log:*), Bash(git blame:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent
 ---

--- a/.claude/commands/lfg.md
+++ b/.claude/commands/lfg.md
@@ -1,6 +1,6 @@
 ---
 description: "Executes full autonomous engineering workflow with verification. Use when implementing complete features, tackling GitHub issues, or running end-to-end development cycles."
-model: claude-opus-4-6
+model: opus
 argument-hint: "GitHub issue number/URL or feature description"
 allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(bundle exec:*), Bash(git:*), Read, Write, Edit, Glob, Grep, Agent
 ---

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,80 @@
+---
+description: "Investigates the codebase, designs a solution, and produces a durable plan artifact — a GitHub issue or a plan markdown under docs/plans/. Read-only: never edits application code. Use before /lfg for anything non-trivial."
+model: fable
+argument-hint: "issue <feature or problem> | md <feature or problem> | <feature or problem>"
+allowed-tools: Bash(gh issue create:*), Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh search:*), Bash(gh label list:*), Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(date:*), Read, Grep, Glob, Write, Agent
+---
+
+# Plan — design expensive, execute cheap
+
+You are the planning specialist. This command runs on the most capable model deliberately: the thinking happens here, the execution happens later on cheaper models (`/lfg` on Opus, layer specialists on Sonnet). That split only works if the plan is **self-contained** — an executor with none of this session's context must be able to implement it without guessing.
+
+## Output mode from $ARGUMENTS
+
+| $ARGUMENTS starts with | Artifact |
+|------------------------|----------|
+| `issue` | GitHub issue (default — feeds directly into `/lfg <issue-number>`) |
+| `md` or `file` | Markdown file at `docs/plans/YYYY-MM-DD-<slug>.md` (date from `date +%F`) |
+| anything else | GitHub issue |
+
+## Hard constraints
+
+- **Read-only for source code.** Never edit application code, never commit, never create branches. The only file you may Write is a new plan markdown under `docs/plans/`.
+- **Never reproduce secrets** (keys, tokens, credentials) in the plan, even redacted ones you encounter while reading config.
+- **Dedupe before creating an issue**: `gh issue list --search "<keywords>"` — if an existing issue covers this, extend it in your summary instead of duplicating.
+
+## Phase 1 — Investigate
+
+Protect this session's context: delegate mechanical exploration to cheaper subagents and keep Fable for judgment.
+
+1. Fan out Explore agents (`model: haiku`) for file discovery and naming-convention sweeps; use `model: sonnet` agents when a subsystem needs to be read and summarized. Launch independent explorations in parallel.
+2. Read the load-bearing files yourself — the ones the design decision actually hinges on. Don't design from subagent summaries alone.
+3. Check `CLAUDE.md` for architecture notes, lock types, and common pitfalls — past decisions and gotchas live there.
+4. Review Lua scripts in `lib/sidekiq_unique_jobs/lua/` and lock implementations in `lib/sidekiq_unique_jobs/lock/` for relevant patterns.
+5. Check `git log` for recent related work; the design should extend it, not fight it.
+
+## Phase 2 — Design
+
+- Develop 2–3 candidate approaches with real tradeoffs. Pick one and say why; record why the others lost.
+- The chosen design must respect project invariants: Lua scripts for atomic Redis operations, lock lifecycle management (acquire → execute → release), conflict resolution strategies, the reflection/observability system, and backwards compatibility with existing lock types.
+- Decide the test strategy: integration specs with real Redis for lock behavior, Lua-specific specs for Redis operations, unit specs for configuration.
+
+## Phase 3 — Emit the plan artifact
+
+Use this structure for the issue body or markdown file. Every section is load-bearing — an executor uses Context to avoid re-discovery, Steps to act, Gates to verify, Boundaries to stop.
+
+```markdown
+# <Title>
+
+## Problem / Goal
+<What's wrong or missing, who it affects, what done looks like.>
+
+## Context (read these first)
+<Bullet list: `path/to/file.rb` — why it matters to this change. Include lock types, Lua scripts, middleware, conflict strategies, specs. Self-contained: no references to "as discussed" or this session.>
+
+## Decision
+<Chosen approach and rationale. Then: alternatives considered and why each was rejected.>
+
+## Implementation steps
+<Ordered, small. Specs come before the code they cover. Name exact files to create or change. Note any Lua script changes needed.>
+
+## Verification gates
+<Exact commands + expected outcome:>
+- `bundle exec rspec <paths>` — all green
+- `bundle exec rubocop` — no offenses
+- `bundle exec rake reek` — clean
+
+## Out of scope
+<Explicit boundaries — the adjacent things an eager executor must NOT do.>
+
+## Execution
+Execute with `/lfg <issue-number>` (or `/lfg docs/plans/<file>.md`).
+```
+
+For GitHub issues: create with `gh issue create --title "..." --body "$(cat <<'EOF' ... EOF)"` — single-quoted heredoc delimiter, backticks unescaped. Apply the `plan` label if it exists (`gh label list`); don't create labels.
+
+For markdown files: Write to `docs/plans/YYYY-MM-DD-<slug>.md`. Leave it uncommitted — committing is the user's call.
+
+## Phase 4 — Handoff
+
+Report back: link to the issue (or file path), the chosen approach in 2–3 sentences, and the exact execute command. Stop there — do not start implementing.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,6 +1,6 @@
 ---
 description: Review a GitHub pull request for code quality, patterns, and best practices
-model: claude-opus-4-6
+model: opus
 argument-hint: "PR URL or number (e.g., 923 or https://github.com/mhenrixon/sidekiq-unique-jobs/pull/923)"
 ---
 

--- a/.claude/commands/security.md
+++ b/.claude/commands/security.md
@@ -1,6 +1,6 @@
 ---
 description: "Reviews code for security vulnerabilities. Use when auditing Redis operations, checking for injection risks, reviewing Lua scripts, or scanning for unsafe patterns."
-model: claude-opus-4-6
+model: opus
 argument-hint: "code, feature, or area to review for security"
 ---
 

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -1,5 +1,6 @@
 ---
 description: "Use when implementing any feature or fixing any bug -- enforces RED-GREEN-REFACTOR: write failing test first, implement minimum code to pass, then refactor."
+model: sonnet
 ---
 
 # TDD Command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,10 @@ Workers can define `after_unlock` instance or class method for cleanup after loc
 - `spec/` - RSpec test suite organized by component
 - `myapp/` - Example Rails application for testing and development
 
+## Working with Claude in this repo
+
+Commands and agents pin a model tier via frontmatter aliases: `sonnet` for CI/review/TDD specialists, `opus` for orchestration, security, and PR review. Use aliases, not full model IDs, so commands track the latest model in each tier. When spawning subagents for mechanical work (file finding, pattern scans), pass a cheaper model explicitly rather than letting them inherit the session model.
+
 ## Common Pitfalls
 
 1. **Lock digest issues**: If uniqueness isn't working as expected, check what's included in the digest (queue, worker class, args). Use `lock_info: true` to debug.


### PR DESCRIPTION
## Summary

- Replaces `model: claude-opus-4-6` with tier aliases (`opus`, `sonnet`) across all 6 existing commands
- Adds `model: sonnet` to `/tdd` which had no model pin (was inheriting session model)
- Adds new `/plan` command (`model: fable`) for read-only planning that produces GitHub issues or plan markdown for cheaper models to execute
- Documents the tier convention in `CLAUDE.md`

| Tier | Commands | Rationale |
|------|----------|-----------|
| `fable` | `/plan` (new) | Read-only planning: investigates, designs, emits a self-contained issue or `docs/plans/` markdown for cheaper models to execute |
| `opus` | `/lfg`, `/review-pr`, `/security` | Orchestration, security audits |
| `sonnet` | `/tdd`, `/github-ci-failures`, `/github-review-comments` | Pattern-following implementation with prescriptive prompts |

## Test plan

- [x] `grep -rn "claude-opus\|claude-sonnet" .claude/ CLAUDE.md` — no full model IDs remain
- [x] All 7 commands + `/plan` have a `model:` tier alias
- [x] `/plan` registers as an available skill
- [ ] Run `/tdd` and confirm it runs on Sonnet
- [ ] Run `/plan` on a small feature and execute the resulting issue with `/lfg`

Docs/config only — no application code, no specs affected.